### PR TITLE
process: describe sec team membership and policy

### DIFF
--- a/processes/security_team_members.md
+++ b/processes/security_team_members.md
@@ -2,10 +2,10 @@
 
 Node.js security team members are expected to keep all information that they have
 privileged access to by being on the team completely private to the team. This
-includes notifying anyone outside the team of issues that have not yet been
-disclosed publicly, including the existence of issues, expectations of upcoming
-releases, and patching of any issues other than in the process of their work as
-a member of the security team.
+includes agreeing to not notify anyone outside the team of issues that have not
+yet been disclosed publicly, including the existence of issues, expectations of
+upcoming releases, and patching of any issues other than in the process of their
+work as a member of the security team.
 
 Membership on the security teams can be requested via an issue in the TSC repo,
 and must be approved by current team members.

--- a/processes/security_team_members.md
+++ b/processes/security_team_members.md
@@ -60,4 +60,5 @@ List is from [nodejs/teams/security](https://github.com/orgs/nodejs/teams/securi
 
 See [nodejs-private/node-private](https://github.com/nodejs-private/node-private).
 
-TBD - why is this list not the same as the team with access to security issues?
+Every member of the team with access to security issues should have access to
+the private security patches as well.

--- a/processes/security_team_members.md
+++ b/processes/security_team_members.md
@@ -1,6 +1,6 @@
 # Node.js Security Team
 
-Node.js security teams are expected to keep all information that they have
+Node.js security team members are expected to keep all information that they have
 privileged access to by being on the team completely private to the team. This
 includes notifying anyone outside the team of issues that have not yet been
 disclosed publically, including the existence of issues, expectations of
@@ -13,7 +13,7 @@ and must be approved by current team members.
 Members of the security teams should indicate that they accept the privacy
 policies by PRing their acceptance to this file.
 
-## Team that triages security reports
+## Team that triages security reports against node core
 
 - @bnoordhuis - **Ben Noordhuis**
 - @indutny - **Fedor Indutny**

--- a/processes/security_team_members.md
+++ b/processes/security_team_members.md
@@ -1,0 +1,63 @@
+# Node.js Security Team
+
+Node.js security teams are expected to keep all information that they have
+privileged access to by being on the team completely private to the team. This
+includes notifying anyone outside the team of issues that have not yet been
+disclosed publically, including the existence of issues, expectations of
+upcoming releases, and patching of any issues other than in the process of
+their work as a member of the security team.
+
+Membership on the security teams can be requested via an issue in the TSC repo,
+and must be approved by current team members.
+
+Members of the security teams should indicate that they accept the privacy
+policies by PRing their acceptance to this file.
+
+## Team that triages security reports
+
+- @bnoordhuis - **Ben Noordhuis**
+- @indutny - **Fedor Indutny**
+- @rvagg - **Rod Vagg**
+- @jasnell - **James M Snell**
+- @shigeki - **Shigeki Ohtsu**
+- @MylesBorins - **Myles Borins**
+
+List is from ["security" alias](https://github.com/nodejs/email/blob/master/iojs.org/aliases.json).
+
+## Team with access to security issues
+
+- @ChALkeR - **Сковорода Никита Андреевич**
+- @Fishrock123 - **Jeremiah Senkpiel**
+- @MylesBorins - **Myles Borins**
+- @Trott - **Rich Trott**
+- @addaleax - **Anna Henningsen**
+- @bnoordhuis - **Ben Noordhuis**
+- @cjihrig - **Colin Ihrig**
+- @dougwilson - **Douglas Wilson**
+- @ejratl - **Emily Ratliff**
+- @evanlucas - **Evan Lucas**
+- @evilpacket - **Adam Baldwin**
+- @grnd - **Danny Grander**
+- @indutny - **Fedor Indutny**
+- @jasnell - **James M Snell**
+- @jbergstroem - **Johan Bergström**
+- @joaocgreis - **João Reis**
+- @joshgav - **Josh Gavant**
+- @mhdawson - **Michael Dawson**
+- @mscdex - **Brian White**
+- @ofrobots - **Ali Ijaz Sheikh**
+- @rvagg - **Rod Vagg**
+- @saghul - **Saúl Ibarra Corretgé**
+- @sam-github - **Sam Roberts**
+- @shigeki - **Shigeki Ohtsu**
+- @targos - **Michaël Zasso**
+- @thefourtheye - **Sakthipriyan Vairamani**
+- @trevnorris - **Trevor Norris**
+
+List is from [nodejs/teams/security](https://github.com/orgs/nodejs/teams/security/members).
+
+## Team with access to private security patches
+
+See [nodejs-private/node-private](https://github.com/nodejs-private/node-private).
+
+TBD - why is this list not the same as the team with access to security issues?

--- a/processes/security_team_members.md
+++ b/processes/security_team_members.md
@@ -3,9 +3,9 @@
 Node.js security team members are expected to keep all information that they have
 privileged access to by being on the team completely private to the team. This
 includes notifying anyone outside the team of issues that have not yet been
-disclosed publically, including the existence of issues, expectations of
-upcoming releases, and patching of any issues other than in the process of
-their work as a member of the security team.
+disclosed publicly, including the existence of issues, expectations of upcoming
+releases, and patching of any issues other than in the process of their work as
+a member of the security team.
 
 Membership on the security teams can be requested via an issue in the TSC repo,
 and must be approved by current team members.
@@ -58,7 +58,35 @@ List is from [nodejs/teams/security](https://github.com/orgs/nodejs/teams/securi
 
 ## Team with access to private security patches
 
-See [nodejs-private/node-private](https://github.com/nodejs-private/node-private).
+- @addaleax     Anna Henningsen
+- @bnoordhuis	Ben Noordhuis
+- @ChALkeR	Сковорода Никита Андреевич
+- @cjihrig	Colin Ihrig
+- @dougwilson	Douglas Wilson
+- @evanlucas	Evan Lucas
+- @evilpacket	Adam Baldwin
+- @Fishrock123	Jeremiah Senkpiel
+- @hackygolucky	Tracy
+- @indutny	Fedor Indutny
+- @jasnell	James M Snell
+- @jbergstroem	Johan Bergström
+- @joaocgreis	João Reis
+- @joshgav	Josh Gavant
+- @mhdawson	Michael Dawson
+- @mrhinkle	Mark Hinkle
+- @MylesBorins	Myles Borins
+- @ofrobots	Ali Ijaz Sheikh
+- @rvagg	Rod Vagg
+- @saghul	Saúl Ibarra Corretgé
+- @sam-github	Sam Roberts
+- @targos	Michaël Zasso
+- @thefourtheye	Sakthipriyan Vairamani
+- @Trott	Rich Trott
+
+List is from
+[orgs/nodejs-private/people](https://github.com/orgs/nodejs-private/people),
+who have access to
+[nodejs-private/node-private](https://github.com/nodejs-private/node-private).
 
 Every member of the team with access to security issues should have access to
 the private security patches as well.


### PR DESCRIPTION
as discussed in https://github.com/nodejs/security-wg/pull/55, attempt to describe privacy policy for sec team