### PR TITLE
Updated link to Code of conduct

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 The [Node.js Code of Conduct][] applies to this repo.
 
-[Node.js Code of Conduct]: https://github.com/nodejs/node/blob/master/CODE_OF_CONDUCT.md
+[Node.js Code of Conduct]: https://github.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md
 
 ## Developer's Certificate of Origin 1.1
 


### PR DESCRIPTION
The prior link pointed to a page that said

> # Code of Conduct
>
> The Node.js Code of Conduct document has moved to https://github.com/nodejs/TSC/blob/master/CODE_OF_CONDUCT.md. 
>
> Please update links to this document accordingly.