### PR TITLE
policy for inclusion in @nodejs/security

### DIFF
--- a/processes/security_team_membership_policy.md
+++ b/processes/security_team_membership_policy.md
@@ -9,8 +9,8 @@ public availability.
 > @nodejs/security membership. See the [membership list](./security_team_members.md)
 > for details. This situation is intended to be corrected in the near future.
 
-This isn't to be confused with the security triage team, which is currently
-defined by the [`security@nodejs.org` email alias](https://github.com/nodejs/email/blob/master/iojs.org/aliases.json).
+This is different than the security triage team, which is defined by the
+[`security@nodejs.org` email alias](https://github.com/nodejs/email/blob/master/iojs.org/aliases.json).
 Inclusion in that group is on a volunteer basis, upon approval by the Technical
 Steering Committee (ie. @nodejs/TSC).
 

--- a/processes/security_team_membership_policy.md
+++ b/processes/security_team_membership_policy.md
@@ -16,7 +16,7 @@ Steering Committee (ie. @nodejs/TSC).
 
 The policy for inclusion on the @nodejs/security is as follows:
 
-1. All members of the Technical Steering Committee (i.e. @nodejs/TSC) are
+1. All members of the Technical Steering Committee (@nodejs/TSC) are
    members of @nodejs/security.
 2. On a case-by-case basis, individuals outside the Technical Steering Committee
    are invited by the TSC to join @nodejs/security so that their expertise can

--- a/processes/security_team_membership_policy.md
+++ b/processes/security_team_membership_policy.md
@@ -1,0 +1,28 @@
+# Node.js Security Team Membership Policy
+
+The Node.js Security Team, namely the @nodejs/security team on Github, has
+access to security-sensitive issues and patches that aren't approriate for
+public availability.
+
+> Note: Due to implementation details and a bit of human error, the list of
+> people with access to the security patches isn't 100% in line with the
+> @nodejs/security membership. See the [membership list](./security_team_members.md)
+> for details. This situation is intended to be corrected in the near future.
+
+This isn't to be confused with the security triage team, which is currently
+defined by the [`security@nodejs.org` email alias](https://github.com/nodejs/email/blob/master/iojs.org/aliases.json).
+Inclusion in that group is on a volunteer basis, upon approval by the Technical
+Steering Committee (ie. @nodejs/TSC).
+
+The policy for inclusion on the @nodejs/security is as follows:
+
+1. All members of the Technical Steering Committee (i.e. @nodejs/TSC) are
+   members of @nodejs/security.
+2. On a case-by-case basis, individuals outside the Technical Steering Committee
+   are invited by the TSC to join @nodejs/security so that their expertise can
+   be applied to an issue or patch. Once their assistance is no longer required
+   for a particular issue or patch, they are removed from the team.
+3. Members of the [release team](https://github.com/nodejs/node#release-team)
+   who are not also members of the TSC are also members of @nodejs/security, as
+   they need access to the patches in order to produce releases.
+4. Members of the security triage team are members of @nodejs/security.

--- a/processes/security_team_membership_policy.md
+++ b/processes/security_team_membership_policy.md
@@ -12,7 +12,7 @@ public availability.
 This is different than the security triage team, which is defined by the
 [`security@nodejs.org` email alias](https://github.com/nodejs/email/blob/master/iojs.org/aliases.json).
 Inclusion in that group is on a volunteer basis, upon approval by the Technical
-Steering Committee (ie. @nodejs/TSC).
+Steering Committee (@nodejs/TSC).
 
 The policy for inclusion on the @nodejs/security is as follows:
 

--- a/processes/security_team_membership_policy.md
+++ b/processes/security_team_membership_policy.md
@@ -1,7 +1,7 @@
 # Node.js Security Team Membership Policy
 
 The Node.js Security Team (@nodejs/security) has
-access to security-sensitive issues and patches that aren't approriate for
+access to security-sensitive issues and patches that aren't appropriate for
 public availability.
 
 > Note: Due to implementation details and a bit of human error, the list of

--- a/processes/security_team_membership_policy.md
+++ b/processes/security_team_membership_policy.md
@@ -22,6 +22,6 @@ The policy for inclusion on the @nodejs/security is as follows:
    be applied to an issue or patch. Once their assistance is no longer required
    for a particular issue or patch, they are removed from the team.
 3. Members of the [release team](https://github.com/nodejs/node#release-team)
-   who are not also members of the TSC are also members of @nodejs/security, as
-   they need access to the patches in order to produce releases.
+   are also members of @nodejs/security, as they need access to the patches in
+   order to produce releases.
 4. Members of the security triage team are members of @nodejs/security.

--- a/processes/security_team_membership_policy.md
+++ b/processes/security_team_membership_policy.md
@@ -1,6 +1,6 @@
 # Node.js Security Team Membership Policy
 
-The Node.js Security Team, namely the @nodejs/security team on Github, has
+The Node.js Security Team (@nodejs/security) has
 access to security-sensitive issues and patches that aren't approriate for
 public availability.
 

--- a/processes/security_team_membership_policy.md
+++ b/processes/security_team_membership_policy.md
@@ -12,7 +12,7 @@ public availability.
 This is different than the security triage team, which is defined by the
 [`security@nodejs.org` email alias](https://github.com/nodejs/email/blob/master/iojs.org/aliases.json).
 Inclusion in that group is on a volunteer basis, upon approval by the Technical
-Steering Committee (@nodejs/TSC).
+Steering Committee (TSC).
 
 The policy for inclusion on the @nodejs/security is as follows:
 

--- a/processes/security_team_membership_policy.md
+++ b/processes/security_team_membership_policy.md
@@ -16,8 +16,7 @@ Steering Committee (TSC).
 
 The policy for inclusion on the @nodejs/security is as follows:
 
-1. All members of the Technical Steering Committee (@nodejs/TSC) are
-   members of @nodejs/security.
+1. All members of @nodejs/TSC are members of @nodejs/security.
 2. On a case-by-case basis, individuals outside the Technical Steering Committee
    are invited by the TSC to join @nodejs/security so that their expertise can
    be applied to an issue or patch. Once their assistance is no longer required


### PR DESCRIPTION
As discussed in the most recent meeting (https://github.com/nodejs/security-wg/blob/master/meetings/2017-11-02.md), this is an attempt to capture the current policy for inclusion in @nodejs/security, as discussed during the meeting primarily by @mhdawson. I've also added a small bit of aspiration to it, in that there is the notion of removing people from the team who are no longer required to be on it (i.e. they are not TSC or release team).

Note that this is intended as a starting point for discussion, and is not necessarily finalized policy.

/cc @nodejs/security-wg