### PR TITLE
add triage team members

### DIFF
--- a/processes/third_party_vuln_process.md
+++ b/processes/third_party_vuln_process.md
@@ -92,8 +92,8 @@ as the [Node.js Security Team](https://github.com/nodejs/security-wg/blob/master
 Members of the security teams should indicate that they accept the privacy policies 
 by PRing their acceptance to this file:
 
-* @vdeturckheim - Vladimir de Turckheim
-* @sam-github - Sam Roberts
-* @cjihrig - Colin Ihrig
 * @bengl - Bryan English
 * @brycebaril - Bryce Baril
+* @cjihrig - Colin Ihrig
+* @sam-github - Sam Roberts
+* @vdeturckheim - Vladimir de Turckheim

--- a/processes/third_party_vuln_process.md
+++ b/processes/third_party_vuln_process.md
@@ -93,3 +93,7 @@ Members of the security teams should indicate that they accept the privacy polic
 by PRing their acceptance to this file:
 
 * @vdeturckheim - Vladimir de Turckheim
+* @sam-github - Sam Roberts
+* @cjihrig - Colin Ihrig
+* @bengl - Bryan English
+* @brycebaril - Bryce Baril


### PR DESCRIPTION
Following https://github.com/nodejs/security-wg/issues/73

@nodejs/security-wg please +1 or -1 this. I'd like to have this merged in order to invite members to the team. Once this is done, we will need to spread the word and handle the few issues already reported on HackerOne.

cc @sam-github @cjihrig @bengl @sam-github @brycebaril