### PR TITLE
add Liran Tal as group member.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ management.
 * [jasnell](https://github.com/jasnell) - **James M Snell**
 * [jbergstroem](https://github.com/jbergstroem) - **Johan Bergström**
 * [joshgav](https://github.com/joshgav) - **Josh Gavant**
+* [lirantal](https://github.com/lirantal) - **Liran Tal**
 * [mcollina](https://github.com/mcollina) - **Matteo Collina**
 * [mdawson](https://github.com/mdawson) - **Michael Dawson**
 * [mgalexander](https://github.com/mgalexander) - **Michael Alexander**


### PR DESCRIPTION
I would like to nominate Liran Tal as a member of te Security WG:

* Liran [requested to join the ecosystem triage team](https://github.com/nodejs/security-wg/pull/78) and the [process](https://github.com/nodejs/security-wg/blob/master/processes/third_party_vuln_process.md#the-triage-team) state that triage team members must be WG members.

* [Liran](https://www.linkedin.com/in/talliran/) has published some very good security content and  [a book](https://leanpub.com/nodejssecurity)

Since our next meeting is only next month, if @nodejs/security-wg  accepts it, I would like to have Liran becoming a member ASAP in order to have him join the ecosystem triage team.