### PR TITLE
Responsible Disclosure Policy template for 3rd party module authors

### DIFF
--- a/processes/responsible_disclosure_template.md
+++ b/processes/responsible_disclosure_template.md
@@ -1,0 +1,15 @@
+# Responsible Disclosure Policy
+
+A responsible disclosure policy helps protect the project and its users from security vulnerabilities discovered in the project’s scope by employing a process where vulnerabilities are publicly disclosed after a reasonable time period to allow patching the vulnerability. 
+
+All security bugs are taken seriously and are considered as top priority. 
+Your efforts to responsibly disclose your findings are appreciated and will be taken into account to acknowledge your contributions.
+
+
+## Reporting a Security Issue
+
+Any security related issue should be reported to the project’s maintainers and the [Node.js Ecosystem](https://hackerone.com/nodejs-ecosystem
+) program hosted on HackerOne which follows the [3rd party responsible disclosure process](https://github.com/nodejs/security-wg/blob/master/processes/third_party_vuln_process.md) set by the Node.js Security WG.
+
+As an alternative method, vulnerabilities can also be reported by emailing security-ecosystem@nodejs.org.
+


### PR DESCRIPTION
Addressing #93 with regards to a template that 3rd party module authors can use in their projects as a `SECURITY.md` resource.

Some general notes:
- I liked @vdeturckheim's "Report a Vulnerability" button thing. I was immediately thinking about a README badge kind of thing. Would be cool to experiment with some "security badge" concepts.
- Bugcrowd created a [richer version](https://github.com/bugcrowd/disclosure-policy/blob/master/responsible_disclosure_policy.md) of this that was meant to be adopted by projects, though I find it a full blown policy while we already have the policy defined and would want to optimize for engagement with short and clear security awareness.

Looking forward for review on style, structure and contents of the template.