### PR TITLE
vulns update hoek and add 4 other prototype pollution

### DIFF
--- a/vuln/npm/367.json
+++ b/vuln/npm/367.json
@@ -9,11 +9,11 @@
   "cves": [
     "CVE-2018-3728"
   ],
-  "vulnerable_versions": "<5.0.3",
-  "patched_versions": ">=5.0.3",
+  "vulnerable_versions": "<5.0.3 >=5.0.0 || < 4.2.1",
+  "patched_versions": ">=5.0.3 >=4.2.1",
   "slug": "hoek-prototype-pollution",
-  "overview": "hoek node module before 5.0.3 suffers from a prototype pollution vulnerability via 'merge' and 'applyToDefaults' functions, which allows a malicious user to modify the prototype of 'Object' via __proto__, causing the addition or modification of an existing property that will exist on all objects.",
-  "recommendation": "Update module to 5.0.3 or higher",
+  "overview": "hoek node module before 5.0.3 and before 4.2.1 suffers from a prototype pollution vulnerability via 'merge' and 'applyToDefaults' functions, which allows a malicious user to modify the prototype of 'Object' via __proto__, causing the addition or modification of an existing property that will exist on all objects.",
+  "recommendation": "Update module to 5.0.3 or 4.2.1 or higher",
   "references": "https://hackerone.com/reports/310439",
   "cvss_vector": "CVSS:3.0/AV:L/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:L",
   "cvss_score": 2.5,

--- a/vuln/npm/369.json
+++ b/vuln/npm/369.json
@@ -1,0 +1,21 @@
+{
+  "id": 369,
+  "created_at": "2018-02-15",
+  "updated_at": "2018-02-15",
+  "title": "mixin-deep prototype pollution",
+  "author": "Olivier Arteau (HoLyVieR)",
+  "module_name": "mixin-deep",
+  "publish_date": "2018-02-15",
+  "cves": [
+    "CVE-2018-3719"
+  ],
+  "vulnerable_versions": "<1.3.1",
+  "patched_versions": ">=1.3.1",
+  "slug": "mixin-deep-prototype-pollution",
+  "overview": "mixin-deep node module before 1.3.1 suffers from a prototype pollution vulnerability via merging functions, which allows a malicious user to modify the prototype of 'Object' via __proto__, causing the addition or modification of an existing property that will exist on all objects.",
+  "recommendation": "Update module to 1.3.1 or higher",
+  "references": "https://hackerone.com/reports/311236",
+  "cvss_vector": "CVSS:3.0/AV:L/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:L",
+  "cvss_score": 1.8,
+  "coordinating_vendor": ""
+}

--- a/vuln/npm/370.json
+++ b/vuln/npm/370.json
@@ -1,0 +1,21 @@
+{
+  "id": 370,
+  "created_at": "2018-02-15",
+  "updated_at": "2018-02-15",
+  "title": "assign-deep prototype pollution",
+  "author": "Olivier Arteau (HoLyVieR)",
+  "module_name": "assign-deep",
+  "publish_date": "2018-02-15",
+  "cves": [
+    "CVE-2018-3720"
+  ],
+  "vulnerable_versions": "<10.4.7",
+  "patched_versions": ">=0.4.7",
+  "slug": "assign-deep-prototype-pollution",
+  "overview": "assign-deep node module before 0.4.7 suffers from a prototype pollution vulnerability via merging functions, which allows a malicious user to modify the prototype of 'Object' via __proto__, causing the addition or modification of an existing property that will exist on all objects.",
+  "recommendation": "Update module to 0.4.7 or higher",
+  "references": "https://hackerone.com/reports/310707",
+  "cvss_vector": "CVSS:3.0/AV:L/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:L",
+  "cvss_score": 1.8,
+  "coordinating_vendor": ""
+}

--- a/vuln/npm/370.json
+++ b/vuln/npm/370.json
@@ -9,7 +9,7 @@
   "cves": [
     "CVE-2018-3720"
   ],
-  "vulnerable_versions": "<10.4.7",
+  "vulnerable_versions": "<0.4.7",
   "patched_versions": ">=0.4.7",
   "slug": "assign-deep-prototype-pollution",
   "overview": "assign-deep node module before 0.4.7 suffers from a prototype pollution vulnerability via merging functions, which allows a malicious user to modify the prototype of 'Object' via __proto__, causing the addition or modification of an existing property that will exist on all objects.",

--- a/vuln/npm/371.json
+++ b/vuln/npm/371.json
@@ -1,0 +1,21 @@
+{
+  "id": 371,
+  "created_at": "2018-02-15",
+  "updated_at": "2018-02-15",
+  "title": "merge-deep prototype pollution",
+  "author": "Olivier Arteau (HoLyVieR)",
+  "module_name": "merge-deep",
+  "publish_date": "2018-02-15",
+  "cves": [
+    "CVE-2018-3722"
+  ],
+  "vulnerable_versions": "<3.0.1",
+  "patched_versions": ">=3.0.1",
+  "slug": "merge-deep-prototype-pollution",
+  "overview": "merge-deep node module before 3.0.1 suffers from a prototype pollution vulnerability via merging functions, which allows a malicious user to modify the prototype of 'Object' via __proto__, causing the addition or modification of an existing property that will exist on all objects.",
+  "recommendation": "Update module to 3.0.1 or higher",
+  "references": "https://hackerone.com/reports/310708",
+  "cvss_vector": "CVSS:3.0/AV:L/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:L",
+  "cvss_score": 1.8,
+  "coordinating_vendor": ""
+}

--- a/vuln/npm/372.json
+++ b/vuln/npm/372.json
@@ -1,0 +1,21 @@
+{
+  "id": 372,
+  "created_at": "2018-02-15",
+  "updated_at": "2018-02-15",
+  "title": "defaults-deep prototype pollution",
+  "author": "Olivier Arteau (HoLyVieR)",
+  "module_name": "defaults-deep",
+  "publish_date": "2018-02-15",
+  "cves": [
+    "CVE-2018-3723"
+  ],
+  "vulnerable_versions": "<0.2.4",
+  "patched_versions": ">=0.2.4",
+  "slug": "defaults-deep-prototype-pollution",
+  "overview": "defaults-deep node module before 0.2.4 suffers from a prototype pollution vulnerability via merging functions, which allows a malicious user to modify the prototype of 'Object' via __proto__, causing the addition or modification of an existing property that will exist on all objects.",
+  "recommendation": "Update module to 0.2.4 or higher",
+  "references": "https://hackerone.com/reports/310514",
+  "cvss_vector": "CVSS:3.0/AV:L/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:L",
+  "cvss_score": 1.8,
+  "coordinating_vendor": ""
+}


### PR DESCRIPTION
CVE-2018-3728 fix has been backported to hoek 4.x (see https://github.com/hapijs/hoek/pull/231)

ping @nlf 
cc @grnd 