### PR TITLE
Refinements to the responsible disclosure template

### DIFF
--- a/processes/responsible_disclosure_template.md
+++ b/processes/responsible_disclosure_template.md
@@ -1,3 +1,5 @@
+This project participates in the Responsible Disclosure Policy program for the Node.js Security Ecosystem.
+
 # Responsible Disclosure Policy
 
 A responsible disclosure policy helps protect the project and its users from security vulnerabilities discovered in the project’s scope by employing a process where vulnerabilities are publicly disclosed after a reasonable time period to allow patching the vulnerability. 
@@ -8,8 +10,8 @@ Your efforts to responsibly disclose your findings are appreciated and will be t
 
 ## Reporting a Security Issue
 
-Any security related issue should be reported to the project’s maintainers and the [Node.js Ecosystem](https://hackerone.com/nodejs-ecosystem
-) program hosted on HackerOne which follows the [3rd party responsible disclosure process](https://github.com/nodejs/security-wg/blob/master/processes/third_party_vuln_process.md) set by the Node.js Security WG.
+Any security related issue should be reported to the [Node.js Ecosystem](https://hackerone.com/nodejs-ecosystem
+) program hosted on HackerOne which follows the [3rd party responsible disclosure process](https://github.com/nodejs/security-wg/blob/master/processes/third_party_vuln_process.md) set by the Node.js Security WG. One may also directly contact the project’s maintainers, but through the HackerOne program the Security WG members will take care of triaging the vulnerability and invite project maintainers to participate in the report.
 
 As an alternative method, vulnerabilities can also be reported by emailing security-ecosystem@nodejs.org.
 


### PR DESCRIPTION
Follow-up on #99:
1. We want to use this text template in a `SECURITY.txt` file that we will PR to projects to have in their repository.
2. Because of (1) I update the text to be less generic and more actionable if someone were to read it in some project's repository.