### PR TITLE
clarify use of CVE for ecosystem

### DIFF
--- a/processes/third_party_vuln_process.md
+++ b/processes/third_party_vuln_process.md
@@ -107,8 +107,7 @@ as the [Node.js Security Team](https://github.com/nodejs/security-wg/blob/master
 Every vulnerability disclosed by the triage team through HackerOne must
 be assigned a CVE number.
 
-Vulnerabilities disclosed to this repository without going through triage
-do not need to be assigned a CVE number.
+Vulnerabilities disclosed to this repository without using HackerOne currently cannot be assigned a CVE by the triage team (we are working to resolve this) but may have a CVE number if was assigned by another entity.
 
 # Members
 

--- a/processes/third_party_vuln_process.md
+++ b/processes/third_party_vuln_process.md
@@ -102,6 +102,16 @@ regular basis.
 Members of this team are required to follow the same NDA and privacy measures
 as the [Node.js Security Team](https://github.com/nodejs/security-wg/blob/master/processes/security_team_members.md).
 
+# Use of CVEs and reference
+
+Every vulnerability disclosed by the triage team through HackerOne must
+be assigned a CVE number.
+
+Vulnerabilities disclosed to this repository without going through triage
+do not need to be assigned a CVE number.
+
+# Members
+
 Members of the security teams should indicate that they accept the privacy policies
 by PRing their acceptance to this file:
 


### PR DESCRIPTION
This PR aims at clarifying when we want to issue a CVE and when we don't need it for the ecosystem vulnerabilities.

WDYT @nodejs/security-wg ?

cc @ChALkeR 