### PR TITLE
vuln-update: give researcher credit

### DIFF
--- a/vuln/npm/382.json
+++ b/vuln/npm/382.json
@@ -3,7 +3,7 @@
   "created_at": "2018-03-03",
   "updated_at": "2018-03-03",
   "title": "XSS in links",
-  "author": "nanalan (https://imalex.xyz)",
+  "author": "joker314 (https://joker314.github.io)",
   "module_name": "mrk.js",
   "publish_date": "2018-03-03",
   "cves": [],


### PR DESCRIPTION
Whoops didn't realise I was supposed to get credit! Oops! In this change I modify the `author` field so that it references the security researcher rather than the author of the package