### PR TITLE
docs(github): auto-assign reviewers based on PR topics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# -- Node.js security ecosystem triage members 
+# These owners will be automatically assigned to any PRs
+# opened for vulnerabilities to be added to the database
+# of the npm community ecosystem
+/vuln/npm/    @nodejs/ecosystem-security
+
+# Currently setting the same ecosystem team to help
+# review any core related PRs as well
+/vuln/core/   @nodejs/ecosystem-security
+
+# -- Node.js Security WG processes 
+# Security WG members who'd like to automatically add
+# themselves to processes PR reviews should be added here
+/processes    @vdeturckheim @lirantal @mhdawson
+


### PR DESCRIPTION
What do you think about an automatically assigned reviewers file based on topics we discuss?

- At least for the triage team I think it's a must due to the traffic we're getting.
- On the processes or other topics I wasn't sure who to list as they would incur inbox "spam" from GitHub and not everyone on the WG are incredibly active and rather just jump-in on interest-basis.

Let me know if you want me to update the file to add you on the auto-reviewers.
