### PR TITLE
Update link to TSC charter issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Security Working Group
 
 ***Note: this group is in the process of seeking Charter by the TSC
-(https://github.com/nodejs/TSC/issues/175)***
+(https://github.com/nodejs/TSC/issues/486)***
 
 ## Mandate
 


### PR DESCRIPTION
The README currently mentions that we're seeking charter and points to <https://github.com/nodejs/TSC/issues/175>, but that issue has been closed for some time. A newer, more urgent-sounding issue now up at <https://github.com/nodejs/TSC/issues/486>.