### PR TITLE
Update reference for bug bounty program for node core

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ management.
 
 ### Node.js Bug Bounty Program
 
-The Node.js project engages in an official bug bounty program for security researches and responsible public disclosures.
+The Node.js project engages in an official bug bounty program for security researchers and responsible public disclosures.
 
 The program is managed through the HackerOne platform at [https://hackerone.com/nodejs](https://hackerone.com/nodejs) with further details.
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ security activities for Node.js core but relies on the Node.js Security Working
 Group to recommend and help maintain policies and procedures for that
 management.
 
+### Node.js Bug Bounty Program
+
+The Node.js project engages in an official bug bounty program for security researches and responsible public disclosures.
+
+The program is managed through the HackerOne platform at [https://hackerone.com/nodejs](https://hackerone.com/nodejs) with further details.
+
+
 ## Current Project Team Members
 
 * [bengl](https://github.com/bengl) - **Bryan English**


### PR DESCRIPTION
Follow-up from #49 

Updates necessary:
- [x] Update Security WG README for clearer communication
- [x] Add a similar reference/link on the HackerOne platform's landing page for the `/nodejs-ecosystem` to refer researches to `/nodejs` for core Node.js issues
- [x] PR to the Node.js website to add similar reference as in our README 

Above makes sense? any other?