### PR TITLE
Add index.js to vuln/ dir to export paths

### DIFF
--- a/vuln/index.js
+++ b/vuln/index.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const path = require('path');
+
+module.exports = {
+  paths: {
+    npm: path.join(__dirname, 'vuln', 'npm'),
+    core: path.join(__dirname, 'vuln', 'core')
+  }
+};


### PR DESCRIPTION
This makes vuln/ dir require-able for future use.

That could include:
 * Listing the vulns
 * Validating the entries to conform to a schema
 * Packaging the vuln/ dir on npm.

Without exporing exact paths, it could be hard to locate the directory in cases where it's placed in another module from the one that consumes it.