### PR TITLE
Add index.js to vuln/ dir to export paths

### DIFF
--- a/tools/vuln_valid/index.js
+++ b/tools/vuln_valid/index.js
@@ -3,9 +3,7 @@ const joi = require('joi').extend(require('joi-extension-semver'));
 const path = require('path');
 const fs = require('fs');
 
-const vulnPath = path.join(__dirname, '..', '..', 'vuln');
-const coreVulnPath = path.join(vulnPath, 'core');
-const npmVulnPath = path.join(vulnPath, 'npm');
+const vulnPaths = require('../../vuln').paths;
 
 const coreModel = joi.object().keys({
   cve: joi.array().items(joi.string().regex(/CVE-\d{4}-\d+/)).required(),
@@ -57,5 +55,5 @@ function validate(dir, model) {
     });
 }
 
-validate(coreVulnPath, coreModel);
-validate(npmVulnPath, npmModel);
+validate(vulnPaths.core, coreModel);
+validate(vulnPaths.npm, npmModel);

--- a/vuln/index.js
+++ b/vuln/index.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const path = require('path');
+
+module.exports = {
+  paths: {
+    npm: path.join(__dirname, 'npm'),
+    core: path.join(__dirname, 'core')
+  }
+};


### PR DESCRIPTION
This makes vuln/ dir require-able for future use.

That could include:
 * Listing the vulns
 * Validating the entries to conform to a schema
 * Packaging the vuln/ dir on npm.

Without exporing exact paths, it could be hard to locate the directory in cases where it's placed in another module from the one that consumes it.