### PR TITLE
Fix version ranges in NSWG-ECO-332

### DIFF
--- a/vuln/npm/332.json
+++ b/vuln/npm/332.json
@@ -12,8 +12,8 @@
     "CVE-2013-4941",
     "and CVE-2013-4942"
   ],
-  "vulnerable_versions": ">=3.0.0 <=3.9.1 =3.10.2",
-  "patched_versions": "=3.10.1 >=3.10.3",
+  "vulnerable_versions": ">=3.0.0 <=3.9.1 || =3.10.2",
+  "patched_versions": "=3.10.1 || >=3.10.3",
   "slug": "yui_xss-via-swf-files",
   "overview": "YUI is a free, open source JavaScript and CSS framework for building richly interactive web applications.\n\nIn the vulnerable versions, the `uploader.swf` and `io.swf` utilities contain a vulnerability allowing cross-site scripting through the `.swf` files used in these components. Through a url accessing these files, and attacker can inject script in the context of these files, potentially exposing cookies or other sensitive information.\n\nThe vulnerability resurfaced in v0.10.2, but only with `io.swf`.",
   "recommendation": "YUI has published their recommendation to fix this issue. \nTheir recommendation is to:\n - Delete self-hosted copies of these files if you are not using them\n - Use the Yahoo! CDN hosted files\n - Use the patched files provided on the YUI Library [here](https://yuilibrary.com/support/20130515-vulnerability/#resolution).",


### PR DESCRIPTION
Those were meaning "none" prior to this patch.
See the references in the 332.json itself.