### PR TITLE
vuln: historic bl memory exposure vulnerability

### DIFF
--- a/vuln/npm/391.json
+++ b/vuln/npm/391.json
@@ -1,0 +1,19 @@
+{
+  "id": 391,
+  "title": "Memory Exposure",
+  "author": "Feross Aboukhadijeh",
+  "module_name": "bl",
+  "created_at": "2017-04-24",
+  "updated_at": "2017-04-24",
+  "publish_date": "2016-01-19",
+  "cves": [],
+  "vulnerable_versions": "<=0.9.4 || 1.0.0",
+  "patched_versions": ">=1.0.1 || >=0.9.5 <1.0.0",
+  "slug": "bl-memory-exposure",
+  "overview": "bl.append(number) in the affected `bl` versions passes a number to Buffer constructor, appeding a chunk of unitialized memory",
+  "recommendation": "update bl to 1.0.1 or higher",
+  "references": "* https://github.com/rvagg/bl/pull/22",
+  "cvss_vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:H",
+  "cvss_score": 6.5,
+  "coordinating_vendor": ""
+}


### PR DESCRIPTION
Similar to 309, but I fixed the vector.

/cc @feross — is the data correct?