### PR TITLE
docs(process): require validation for external reports

### DIFF
--- a/processes/third_party_vuln_process.md
+++ b/processes/third_party_vuln_process.md
@@ -89,6 +89,8 @@ Vulnerabilities found and fixed outside this process should be added into
 the vulnerability database. This can be done by anyone through a Pull Request on
 this repository.
 
+The vulnerability should include any kind of supporting material such as references, maintainer review or otherwise to confirm the vulnerability report is valid.
+
 # The triage team
 
 The triage team is composed of 5 or more members of the security working group.


### PR DESCRIPTION
Reasoning: if someone will want to just add a historic vuln directly on the repo with a PR without going through the triage process on H1 then how can we trust that their vulnerability is real and not spam/fake?

Requiring a CVE that we can validate against, or any other reference/maintainer confirmation will help assure the correctness of the report.