### PR TITLE
vuln(NSWG-ECO-398): [metascrapper] 

### DIFF
--- a/vuln/npm/398.json
+++ b/vuln/npm/398.json
@@ -1,0 +1,21 @@
+{
+  "id": "398",
+  "title": "Cross-site Scripting (XSS) - Stored",
+  "overview": "[metascrapper] Stored XSS in Open Graph meta properties read by metascrapper",
+  "created_at": "2018-01-25",
+  "updated_at": "2018-03-28",
+  "publish_date": "2018-03-28",
+  "author": "bl4de (https://twitter.com/_bl4de)",
+  "module_name": "metascrapper",
+  "cves": [
+    ""
+  ],
+  "vulnerable_versions": ">=3.9.2",
+  "patched_versions": "",
+  "slug": "metascrapper-cross-site-scripting-(xss)---stored",
+  "recommendation": "No fix is currently available for this vulnerability.\n\nIt is our recommendation to not install or use this module at this time.",
+  "references": "- https://www.hackerone.com/reports/309367",
+  "cvss_vector": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:N",
+  "cvss_score": 9.6,
+  "coordinating_vendor": ""
+}


### PR DESCRIPTION
Stored XSS in Open Graph meta properties read by metascrapper

TODO
- [ ] add CVE once assigned