### PR TITLE
vuln(NSWG-ECO-399): whereis 

### DIFF
--- a/vuln/npm/399.json
+++ b/vuln/npm/399.json
@@ -1,0 +1,21 @@
+{
+  "id": "399",
+  "title": "Command Injection - Generic",
+  "overview": "`whereis` concatenates unsanitized input into exec() command",
+  "created_at": "2018-02-25",
+  "updated_at": "2018-03-28",
+  "publish_date": "2018-03-28",
+  "author": "chalker (https://github.com/ChALkeR)",
+  "module_name": "whereis",
+  "cves": [
+    ""
+  ],
+  "vulnerable_versions": "<=0.4.0",
+  "patched_versions": ">=0.4.1",
+  "slug": "whereis-command-injection---generic",
+  "recommendation": "update whereis to 0.4.1 or higher",
+  "references": "- https://www.hackerone.com/reports/319476\n- https://github.com/vvo/node-whereis/commit/0f64e3780235004fb6e43bfd153ea3e0e210ee2b",
+  "cvss_vector": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H",
+  "cvss_score": 9.9,
+  "coordinating_vendor": ""
+}


### PR DESCRIPTION
concatenates unsanitized input into exec command

TODO
- [ ] wait for CVE assigned