### PR TITLE
Fix links to HackerOne reports

### DIFF
--- a/vuln/npm/387.json
+++ b/vuln/npm/387.json
@@ -14,7 +14,7 @@
   "patched_versions": "",
   "slug": "general-file-server-path-traversal",
   "recommendation": "No fix is currently available for this vulnerability.\n\nIt is our recommendation to not install or use this module at this time.",
-  "references": "- https://www.hackerone.com/reports/310943",
+  "references": "- https://hackerone.com/reports/310943",
   "cvss_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N",
   "cvss_score": 8.6,
   "coordinating_vendor": ""

--- a/vuln/npm/389.json
+++ b/vuln/npm/389.json
@@ -14,7 +14,7 @@
   "patched_versions": ">=6.5.2",
   "slug": "serve-information-exposure-through-directory-listing",
   "recommendation": "update serve to 6.5.2 or higher",
-  "references": "- https://www.hackerone.com/reports/308721",
+  "references": "- https://hackerone.com/reports/308721",
   "cvss_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
   "cvss_score": 9.3,
   "coordinating_vendor": ""

--- a/vuln/npm/390.json
+++ b/vuln/npm/390.json
@@ -14,7 +14,7 @@
   "patched_versions": ">=1.1.0",
   "slug": "simple-server-cross-site-scripting-(xss)---stored",
   "recommendation": "update simple-server to 1.1.0 or higher",
-  "references": "- https://www.hackerone.com/reports/309641",
+  "references": "- https://hackerone.com/reports/309641",
   "cvss_vector": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:H/A:N",
   "cvss_score": 7.7,
   "coordinating_vendor": ""


### PR DESCRIPTION
`www.hackerone.com` is an isolated subdomain hosting the landing page and other more complex and less sensitive stuff.

There is a redirect, but it displays an error first.

So, fix the links to the direct links to reports on the actual domain.