### PR TITLE
Fix NSWG-ECO-398 and NSWG-ECO-399 format

### DIFF
--- a/vuln/npm/398.json
+++ b/vuln/npm/398.json
@@ -7,9 +7,7 @@
   "publish_date": "2018-03-28",
   "author": "bl4de (https://twitter.com/_bl4de)",
   "module_name": "metascraper",
-  "cves": [
-    ""
-  ],
+  "cves": [],
   "vulnerable_versions": "<=3.9.2",
   "patched_versions": "",
   "slug": "metascraper-cross-site-scripting-(xss)---stored",

--- a/vuln/npm/399.json
+++ b/vuln/npm/399.json
@@ -7,9 +7,7 @@
   "publish_date": "2018-03-28",
   "author": "Сковорода Никита Андреевич (https://github.com/ChALkeR)",
   "module_name": "whereis",
-  "cves": [
-    ""
-  ],
+  "cves": [],
   "vulnerable_versions": "<=0.4.0",
   "patched_versions": ">=0.4.1",
   "slug": "whereis-command-injection---generic",


### PR DESCRIPTION
Those were using an array with an empty string `[""]` as cves.
Use an empty array instead `[]`.

Now the linter is happy with those.