### PR TITLE
vuln(NSWG-ECO-401): sshpk

### DIFF
--- a/vuln/npm/401.json
+++ b/vuln/npm/401.json
@@ -1,0 +1,19 @@
+{
+  "id": 401,
+  "title": "Denial of Service",
+  "overview": "`sshpk` is vulnerable to ReDoS when parsing crafted invalid public keys",
+  "created_at": "2018-02-25",
+  "updated_at": "2018-04-05",
+  "publish_date": "2018-04-05",
+  "author": "Сковорода Никита Андреевич (https://github.com/ChALkeR)",
+  "module_name": "sshpk",
+  "cves": [],
+  "vulnerable_versions": "<1.14.1",
+  "patched_versions": ">=1.14.1",
+  "slug": "sshpk-denial-of-service",
+  "recommendation": "update sshpk to 1.14.1 or higher",
+  "references": "- https://hackerone.com/reports/319593\n- https://github.com/joyent/node-sshpk/blob/v1.13.1/lib/formats/ssh.js#L17",
+  "cvss_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+  "cvss_score": 7.5,
+  "coordinating_vendor": ""
+}


### PR DESCRIPTION
@ChALkeR where 1.13.1 was vulnerable, there was another 1.13.2 release, and then a bigger 1.14.1
Would 1.14.1 be the minimum secure version then?