### PR TITLE
fix(vuln): NSWG-ECO-402 references

### DIFF
--- a/vuln/npm/402.json
+++ b/vuln/npm/402.json
@@ -12,7 +12,7 @@
   "patched_versions": ">=2.1.0",
   "slug": "http-proxy-agent-denial-of-service",
   "recommendation": "update http-proxy-agent to 2.1.0 or higher",
-  "references": "- https://hackerone.com/reports/321631\n- https://github.com/TooTallNate/node-http-proxy-agent/blob/master/index.js#L80",
+  "references": "- https://hackerone.com/reports/321631\n- https://github.com/TooTallNate/node-http-proxy-agent/blob/2.0.0/index.js#L80",
   "cvss_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:H",
   "cvss_score": 8.2,
   "coordinating_vendor": ""


### PR DESCRIPTION
Fixed references to specific version, as described in https://github.com/nodejs/security-wg/pull/210#discussion_r179915794