### PR TITLE
docs(github): fix triage team tag

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,11 +2,11 @@
 # These owners will be automatically assigned to any PRs
 # opened for vulnerabilities to be added to the database
 # of the npm community ecosystem
-/vuln/npm/    @nodejs/ecosystem-security
+/vuln/npm/    @nodejs/security-triage  
 
 # Currently setting the same ecosystem team to help
 # review any core related PRs as well
-/vuln/core/   @nodejs/ecosystem-security
+/vuln/core/   @nodejs/security-triage 
 
 # -- Node.js Security WG processes 
 # Security WG members who'd like to automatically add


### PR DESCRIPTION
I noticed that vulns don't get auto assigned reviewers from the triage team members and I wonder if this is because there was recently (about a month ago or so) a change in the organization team structure.

Any ideas if this fix is going to solve it or it was something else?