### PR TITLE
Add validation that either vulnerable_versions or patched_versions is present

### DIFF
--- a/tools/vuln_valid/index.js
+++ b/tools/vuln_valid/index.js
@@ -26,7 +26,19 @@ const npmModel = joi.object().keys({
   author: joi.string().allow(null).required(),
   module_name: joi.string().required(),
   publish_date: joi.string().regex(/^\d{4}-\d{2}-\d{2}$/).required(),
-  vulnerable_versions: joi.semver().validRange().allow('').allow(null).required(),
+  vulnerable_versions: joi.alternatives().when("patched_versions", {
+    is: null,
+    then: joi
+      .semver()
+      .validRange()
+      .required(),
+    otherwise: joi
+      .semver()
+      .validRange()
+      .allow("")
+      .allow(null)
+      .required()
+  }),
   patched_versions: joi.semver().validRange().allow('').allow(null).required(),
   slug: joi.string().required(),
   overview: joi.string().required(),


### PR DESCRIPTION
Validate that scenarios like https://github.com/nodejs/security-wg/issues/190 don't exist.

This validation is currently failing - there are problems with the following two advisories:
- [x] https://github.com/nodejs/security-wg/blob/master/vuln/npm/87.json#L10-L11
- [x] https://github.com/nodejs/security-wg/blob/master/vuln/npm/263.json#L10-L11

