### PR TITLE
Fix NSWG-ECO-418 refs

### DIFF
--- a/vuln/npm/418.json
+++ b/vuln/npm/418.json
@@ -11,7 +11,7 @@
   "vulnerable_versions": "<=0.1.0",
   "patched_versions": "",
   "recommendation": "No fix is currently available for this vulnerability.\n\nIt is our recommendation to not install or use this module at this time.",
-  "references": "- https://hackerone.com/reports/319629\n- https://github.com/christian-bromann/rgb2hex/blob/0.1.0/index.js#L25",
+  "references": "- https://hackerone.com/reports/319629\n- https://github.com/christian-bromann/rgb2hex/blob/v0.1.0/index.js#L25",
   "cvss_vector": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
   "cvss_score": 6.5,
   "coordinating_vendor": ""


### PR DESCRIPTION
The correct rgb2hex tag is `v0.1.0`, not `0.1.0`

Refs: https://github.com/nodejs/security-wg/pull/244#discussion_r184876421