### PR TITLE
Fix NSWG-ECO-416 refs

### DIFF
--- a/vuln/npm/416.json
+++ b/vuln/npm/416.json
@@ -11,7 +11,7 @@
   "vulnerable_versions": "<=1.0.5",
   "patched_versions": ">=1.0.6",
   "recommendation": "update concat-with-sourcemaps to 1.0.6 or higher",
-  "references": "- https://hackerone.com/reports/320166\n- https://github.com/floridoo/concat-with-sourcemaps/blob/1.0.5/index.js#L18",
+  "references": "- https://hackerone.com/reports/320166\n- https://github.com/floridoo/concat-with-sourcemaps/blob/v1.0.5/index.js#L18",
   "cvss_vector": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
   "cvss_score": 6.5,
   "coordinating_vendor": ""


### PR DESCRIPTION
The correct concat-with-sourcemaps tag is v1.0.5, not 1.0.5

Refs: https://github.com/nodejs/security-wg/pull/242#discussion_r184864552