### PR TITLE
Fix NSWG-ECO-419 syntax

### DIFF
--- a/vuln/npm/419.json
+++ b/vuln/npm/419.json
@@ -1,7 +1,7 @@
 {
   "id": 419,
   "title": "Path Traversal",
-  "overview": "`superstatic` is vulnerable to path traversal on Windows. Additionally, it is vulnerable to path traversal on other platforms combined with certain Node.js versions which erroneously normalize `\` to `/` in paths on all platforms (a known example being Node.js v9.9.0).",
+  "overview": "`superstatic` is vulnerable to path traversal on Windows. Additionally, it is vulnerable to path traversal on other platforms combined with certain Node.js versions which erroneously normalize `\\` to `/` in paths on all platforms (a known example being Node.js v9.9.0).",
   "created_at": "2018-02-26",
   "updated_at": "2018-04-29",
   "publish_date": "2018-04-29",


### PR DESCRIPTION
`overview` should be JSON-encoded.
Else the parser breaks on `419.json`.

Ref: #247