### PR TITLE
vuln/npm: fix various validation failures

### DIFF
--- a/vuln/npm/403.json
+++ b/vuln/npm/403.json
@@ -12,10 +12,9 @@
   ],
   "vulnerable_versions": "<=2.0.3",
   "patched_versions": ">=2.1.0",
-  "slug": "atob-out-of-bounds-read",
   "recommendation": "update atob to 2.1.0 or higher",
   "references": "- https://hackerone.com/reports/321686",
   "cvss_vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:H",
   "cvss_score": 6.5,
-  "coordinating_vendor": ""
+  "coordinating_vendor": null
 }

--- a/vuln/npm/412.json
+++ b/vuln/npm/412.json
@@ -16,5 +16,5 @@
   "references": "- https://hackerone.com/reports/330957",
   "cvss_vector": "CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:H",
   "cvss_score": 7.8,
-  "coordinating_vendor": ""
+  "coordinating_vendor": null
 }

--- a/vuln/npm/413.json
+++ b/vuln/npm/413.json
@@ -11,10 +11,10 @@
     "CVE-2018-3730"
   ],
   "vulnerable_versions": "<=0.0.20",
-  "patched_versions": "",
+  "patched_versions": null,
   "recommendation": "No fix is currently available for this vulnerability.\n\nIt is our recommendation to not install or use this module at this time.",
   "references": "- https://hackerone.com/reports/312907",
   "cvss_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N",
   "cvss_score": 8.6,
-  "coordinating_vendor": ""
+  "coordinating_vendor": null
 }

--- a/vuln/npm/414.json
+++ b/vuln/npm/414.json
@@ -14,5 +14,5 @@
   "references": "- https://hackerone.com/reports/341044\n- https://github.com/coderaiser/cloudcmd/commit/23f4d4702cd3d473977285f26ea2ae7206b45f38",
   "cvss_vector": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:L/A:N",
   "cvss_score": 8.5,
-  "coordinating_vendor": ""
+  "coordinating_vendor": null
 }

--- a/vuln/npm/415.json
+++ b/vuln/npm/415.json
@@ -14,5 +14,5 @@
   "references": "https://github.com/tanem/react-svg/pull/57",
   "cvss_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
   "cvss_score": 9.1,
-  "coordinating_vendor": ""
+  "coordinating_vendor": null
 }

--- a/vuln/npm/416.json
+++ b/vuln/npm/416.json
@@ -14,5 +14,5 @@
   "references": "- https://hackerone.com/reports/320166\n- https://github.com/floridoo/concat-with-sourcemaps/blob/v1.0.5/index.js#L18",
   "cvss_vector": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
   "cvss_score": 6.5,
-  "coordinating_vendor": ""
+  "coordinating_vendor": null
 }

--- a/vuln/npm/417.json
+++ b/vuln/npm/417.json
@@ -9,10 +9,10 @@
   "module_name": "foreman",
   "cves": [],
   "vulnerable_versions": "<=2.0.0",
-  "patched_versions": "",
+  "patched_versions": null,
   "recommendation": "No fix is currently available for this vulnerability.\n\nIt is our recommendation to not install or use this module at this time.",
   "references": "- https://hackerone.com/reports/320586\n- https://github.com/strongloop/node-foreman/blob/v2.0.0/forward.js#L30",
   "cvss_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
   "cvss_score": 7.5,
-  "coordinating_vendor": ""
+  "coordinating_vendor": null
 }

--- a/vuln/npm/418.json
+++ b/vuln/npm/418.json
@@ -9,10 +9,10 @@
   "module_name": "rgb2hex",
   "cves": [],
   "vulnerable_versions": "<=0.1.0",
-  "patched_versions": "",
+  "patched_versions": null,
   "recommendation": "No fix is currently available for this vulnerability.\n\nIt is our recommendation to not install or use this module at this time.",
   "references": "- https://hackerone.com/reports/319629\n- https://github.com/christian-bromann/rgb2hex/blob/v0.1.0/index.js#L25",
   "cvss_vector": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
   "cvss_score": 6.5,
-  "coordinating_vendor": ""
+  "coordinating_vendor": null
 }

--- a/vuln/npm/419.json
+++ b/vuln/npm/419.json
@@ -9,10 +9,10 @@
   "module_name": "superstatic",
   "cves": [],
   "vulnerable_versions": "<=5.0.1",
-  "patched_versions": "",
+  "patched_versions": null,
   "recommendation": "The fix is available in the master branch, but a new version with the fix has not been released (scheduled for v5.0.2). It is our recommendation to not use this module on Windows (and Linux with certain Node.js versions, e.g. v9.9.0) at this time, or to apply the patch manually. Update to 5.0.2 or later if and when it would be released.",
   "references": "- https://hackerone.com/reports/319951\n- https://github.com/firebase/superstatic/blob/v5.0.1/lib/providers/fs.js#L71\n- https://github.com/firebase/superstatic/commit/e396ff62f588732989137d6c40d46b310e51ef2b\n- https://github.com/firebase/superstatic/pull/255",
   "cvss_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N",
   "cvss_score": 8.6,
-  "coordinating_vendor": ""
+  "coordinating_vendor": null
 }


### PR DESCRIPTION
This makes `npm t` pass, combined with #254.

Removes one `slug` and changes some empty strings to `null`s, like in other files.