### PR TITLE
Add triage-team-only offboarding checklist.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # These owners will be automatically assigned to any PRs
 # opened for vulnerabilities to be added to the database
 # of the npm community ecosystem
-/vuln/npm/    @nodejs/security-triage
+/vuln/npm/    @nodejs/ecosystem-security
 
 # Currently setting the same ecosystem team to help
 # review any core related PRs as well

--- a/processes/security_team_offboarding.md
+++ b/processes/security_team_offboarding.md
@@ -15,9 +15,17 @@ At any time until the last time mark any member can chime in and request to reta
 
 ## Revoking Access to Confidential Systems
 
-The following is a check-list for which existing WG members should be removed access from:
+The following is a check-list of actions to be taken upon departure of users from the Security WG (either voluntarily or due to inactivity as described above):
 * [ ] Remove user from [Repo README](https://github.com/nodejs/security-wg/blob/master/README.md), [Triage Team](https://github.com/nodejs/security-wg/blob/master/processes/third_party_vuln_process.md), [Security Team List](https://github.com/nodejs/security-wg/blob/master/processes/security_team_members.md), [GitHub CodeOwners](https://github.com/nodejs/security-wg/blob/master/.github/CODEOWNERS), 
-* [ ] Remove membership from [Node.js WG Team](https://github.com/orgs/nodejs/teams/security-wg)
+* [ ] Remove membership from [Node.js WG GitHub Team](https://github.com/orgs/nodejs/teams/security-wg) and [Triage GitHub Team](https://github.com/orgs/nodejs/teams/ecosystem-security)
 * [ ] Remove user from [HackerOne platform](hackerone.com/nodejs-ecosystem)
 * [ ] Revoke any user-specific access tokens from HackerOne platform
 * [ ] Remove user access from private team channels in slack (nodejs-security-wg.slack.com)
+
+The following is a check-list of actions to be taken upon voluntary departure of users from the [Third-Party Triage Team](https://github.com/nodejs/security-wg/blob/master/processes/third_party_vuln_process.md), when the users will remain in the Security WG.
+
+* [ ] Remove user from [Triage Team](https://github.com/nodejs/security-wg/blob/master/processes/third_party_vuln_process.md)
+* [ ] Remove membership from [Triage GitHub Team](https://github.com/orgs/nodejs/teams/ecosystem-security)
+* [ ] Remove user from [HackerOne platform](hackerone.com/nodejs-ecosystem)
+* [ ] Revoke any user-specific access tokens from HackerOne platform
+* [ ] Remove user access from private team channels in slack that are specific to the Triage Team (nodejs-security-wg.slack.com)


### PR DESCRIPTION
Also clarifying that the offboarding checklist applies to voluntary and involuntary departures.

Also correcting the team name in CODEOWNERS.