### PR TITLE
vuln(NSWG-ECO-418): rgb2hex

### DIFF
--- a/vuln/npm/418.json
+++ b/vuln/npm/418.json
@@ -8,12 +8,13 @@
   "author": "Сковорода Никита Андреевич (https://github.com/ChALkeR)",
   "module_name": "rgb2hex",
   "cves": [],
-  "vulnerable_versions": "<=0.1.0",
-  "patched_versions": null,
-  "recommendation": "No fix is currently available for this vulnerability.\n\nIt is our recommendation to not install or use this module at this time.",
+  "vulnerable_versions": "<0.1.6",
+  "patched_versions": ">=0.1.6",
+  "recommendation": "Update to version 0.1.6 or later",
   "references": [
     "https://hackerone.com/reports/319629",
-    "https://github.com/christian-bromann/rgb2hex/blob/v0.1.0/index.js#L25"
+    "https://github.com/christian-bromann/rgb2hex/blob/v0.1.0/index.js#L25",
+    "https://github.com/christian-bromann/rgb2hex/commit/9e0c38594432edfa64136fdf7bb651835e17c34f"
   ],
   "cvss_vector": "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
   "cvss_score": 6.5,


### PR DESCRIPTION
Supersedes https://github.com/nodejs/security-wg/pull/335
@ChALkeR are we good to go?