### PR TITLE
doc: add core vulns for August 2018

### DIFF
--- a/tools/vuln_valid/index.js
+++ b/tools/vuln_valid/index.js
@@ -13,6 +13,8 @@ const coreModel = joi.object().keys({
   description: joi.string().optional(),
   overview: joi.string().optional(),
   author: joi.string().optional(),
+  publish_date: joi.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().isoDate(),
+  type: joi.string().optional(),
   cvss_score: joi.string().optional(),
   cvss: joi.string().optional()
 });
@@ -58,7 +60,6 @@ function validate(dir, model) {
   fs.readdirSync(dir)
     .forEach((name) => {
       const filePath = path.join(dir, name);
-      console.log('Validate:', filePath);
       try {
         const vuln = JSON.parse(fs.readFileSync(filePath));
         const result = joi.validate(vuln, model);

--- a/vuln/core/53.json
+++ b/vuln/core/53.json
@@ -1,0 +1,12 @@
+{
+  "cve": [
+    "CVE-2018-7166"
+  ],
+  "vulnerable": "10",
+  "patched": ">= 10.9.0",
+  "publish_date": "2018-08-16",
+  "author": "Сковорода Никита Андреевич (Nikita Skovoroda / @ChALkeR)",
+  "ref": "https://nodejs.org/en/blog/vulnerability/august-2018-security-releases/",
+  "type": "CWE-226: Sensitive Information Uncleared Before Release",
+  "overview": "An argument processing flaw can cause `Buffer.alloc()` to return uninitialized memory. This method is intended to be safe and only return initialized, or cleared, memory. The third argument specifying `encoding` can be passed as a number, this is misinterpreted by `Buffer's` internal \"fill\" method as the `start` to a fill operation. This flaw may be abused where `Buffer.alloc()` arguments are derived from user input to return uncleared memory blocks that may contain sensitive information."
+}

--- a/vuln/core/54.json
+++ b/vuln/core/54.json
@@ -1,0 +1,12 @@
+{
+  "cve": [
+    "CVE-2018-12115"
+  ],
+  "vulnerable": "<= 10",
+  "patched": "^6.14.4 || ^8.11.4 || >= 10.9.0",
+  "publish_date": "2018-08-16",
+  "author": "Сковорода Никита Андреевич (Nikita Skovoroda / @ChALkeR)",
+  "ref": "https://nodejs.org/en/blog/vulnerability/august-2018-security-releases/",
+  "type": "CWE-787: Out-of-bounds Write",
+  "overview": "When used with UCS-2 encoding (recognized by Node.js under the names `'ucs2'`, `'ucs-2'`, `'utf16le'` and `'utf-16le'`), `Buffer#write()` can be abused to write outside of the bounds of a single `Buffer`. Writes that start from the second-to-last position of a buffer cause a miscalculation of the maximum length of the input bytes to be written."
+}


### PR DESCRIPTION
A couple of things I'm doing slightly differently here:

 * `"refs"` — I had this in my last submission but it hasn't been used consistently since, I think it should be.
 * `"credit"` — crediting finding bugs is an important thing to do, creates additional incentive to report
 * `"type"` — Using CWEs, again I did this last time but it hasn't been used consistently and I think it should be. My next PR for docs will mention this this.