### PR TITLE
Add support for pulling CVE IDs for a report from the HackerOne API

### DIFF
--- a/tools/reporter/HackerOneClient.js
+++ b/tools/reporter/HackerOneClient.js
@@ -32,8 +32,6 @@ class HackerOneClient {
 
     const result = {
       data: reportData.data.data,
-      // @TODO API not implemented yet by HackerOne team
-      // cves: reportDataExtended.data.cve_ids,
       reporter: reportUserData.data
     }
 

--- a/tools/reporter/NswgReporter.js
+++ b/tools/reporter/NswgReporter.js
@@ -26,8 +26,7 @@ class NswgReporter {
     wgReport['author'] = this.getAuthorUsername()
     wgReport['module_name'] = this.getModuleName()
 
-    // @TODO missing cves from API
-    wgReport['cves'] = []
+    wgReport['cves'] = this.getCVEs()
 
     // @TODO missing versions information in report
     wgReport['vulnerable_versions'] = this.getVulnerableVerison()
@@ -83,6 +82,10 @@ class NswgReporter {
       website,
       username
     }
+  }
+
+  getCVEs () {
+    return this.report.data.attributes.cve_ids
   }
 
   getModuleName () {


### PR DESCRIPTION
HackerOne's API now provides a report's CVE IDs as part of the response.