### PR TITLE
docs(security-policy): call to action and more info

### DIFF
--- a/processes/responsible_disclosure_template.md
+++ b/processes/responsible_disclosure_template.md
@@ -1,6 +1,7 @@
 This project participates in the Responsible Disclosure Policy program for the Node.js Security Ecosystem.
 
-To report a Security Vulnerability [click here](https://hackerone.com/nodejs-ecosystem)
+* [Report a security vulnerability](https://hackerone.com/nodejs-ecosystem)
+
 
 # Responsible Disclosure Policy
 

--- a/processes/responsible_disclosure_template.md
+++ b/processes/responsible_disclosure_template.md
@@ -1,5 +1,7 @@
 This project participates in the Responsible Disclosure Policy program for the Node.js Security Ecosystem.
 
+To report a Security Vulnerability [click here](https://hackerone.com/nodejs-ecosystem)
+
 # Responsible Disclosure Policy
 
 A responsible disclosure policy helps protect the project and its users from security vulnerabilities discovered in the project’s scope by employing a process where vulnerabilities are publicly disclosed after a reasonable time period to allow patching the vulnerability. 
@@ -11,7 +13,8 @@ Your efforts to responsibly disclose your findings are appreciated and will be t
 ## Reporting a Security Issue
 
 Any security related issue should be reported to the [Node.js Ecosystem](https://hackerone.com/nodejs-ecosystem
-) program hosted on HackerOne which follows the [3rd party responsible disclosure process](https://github.com/nodejs/security-wg/blob/master/processes/third_party_vuln_process.md) set by the Node.js Security WG. One may also directly contact the project’s maintainers, but through the HackerOne program the Security WG members will take care of triaging the vulnerability and invite project maintainers to participate in the report.
+) program hosted on HackerOne which follows the [3rd party responsible disclosure process](https://github.com/nodejs/security-wg/blob/master/processes/third_party_vuln_process.md) set by the Node.js Security WG.
+
+One may also directly contact the project’s maintainers, but through the HackerOne program the Security WG members will take care of triaging the vulnerability and invite project maintainers to participate in the report.
 
 As an alternative method, vulnerabilities can also be reported by emailing security-ecosystem@nodejs.org.
-


### PR DESCRIPTION
- Adding a call to action top link that is more inviting to quickly report a vulnerability
- Cosmetic spaces

FYI I recently saw this custom `SECURITY.MD` https://github.com/unshiftio/url-parse/commit/d7b582ec1243e8024e60ac0b62d2569c939ef5de