### PR TITLE
Rejected: vuln(NSWG-ECO-483): zombie

### DIFF
--- a/vuln/npm/482.json
+++ b/vuln/npm/482.json
@@ -1,0 +1,24 @@
+{
+  "id": 482,
+  "title": "Code Injection",
+  "overview": "Code Injection Vulnerability in zombie Package",
+  "created_at": "2018-08-02",
+  "updated_at": "2018-11-23",
+  "publish_date": "2018-11-23",
+  "author": {
+    "name": "Cristian-Alexandru Staicu",
+    "website": "https://semmle.com/security",
+    "username": "cris_semmle"
+  },
+  "module_name": "zombie",
+  "cves": [],
+  "vulnerable_versions": ">=6.1.3",
+  "patched_versions": null,
+  "recommendation": "No fix is currently available for this vulnerability.\n\nIt is our recommendation to not install or use this module at this time.",
+  "references": [
+    "https://hackerone.com/reports/389583"
+  ],
+  "cvss_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+  "cvss_score": 8.8,
+  "coordinating_vendor": null
+}


### PR DESCRIPTION
- WIP as there's an issue I'm trying to figure out with the maintainer before requesting a CVE: https://github.com/assaf/zombie/issues/1169#issuecomment-441192800
- In this report I've opted-in for flagging all future releases as vulnerable as well because unlike unmaintained packages which are unlikely to be vulnerable, this package is maintained and can easily just release a new minor without a security fix which will get the CVE to not be applied. /cc @nodejs/security-wg maybe we should better settle the policy on this? and also WDYT on this specific case.