### PR TITLE
doc: added 5 vulnerabilities for November 2018 core releases

### DIFF
--- a/tools/vuln_valid/index.js
+++ b/tools/vuln_valid/index.js
@@ -16,7 +16,8 @@ const coreModel = joi.object().keys({
   publish_date: joi.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().isoDate(),
   type: joi.string().optional(),
   cvss_score: joi.string().optional(),
-  cvss: joi.string().optional()
+  cvss: joi.string().optional(),
+  reported_by: joi.string().optional()
 });
 
 const npmModel = joi.object().keys({

--- a/vuln/core/55.json
+++ b/vuln/core/55.json
@@ -1,0 +1,13 @@
+{
+  "cve": [
+    "CVE-2018-12116"
+  ],
+  "vulnerable": "6 || 8",
+  "patched": "^6.15.0 || ^8.14.0",
+  "publish_date": "2018-11-27",
+  "author": "Matteo Collina",
+  "reported_by": "Arkadiy Tetelman",
+  "ref": "https://nodejs.org/en/blog/vulnerability/november-2018-security-releases/",
+  "type": "CWE-115: Misinterpretation of Input",
+  "overview": "HTTP request splitting: If Node.js can be convinced to use unsanitized user-provided Unicode data for the `path` option of an HTTP request, then data can be provided which will trigger a second, unexpected, and user-defined HTTP request to made to the same server."
+}

--- a/vuln/core/56.json
+++ b/vuln/core/56.json
@@ -1,0 +1,13 @@
+{
+  "cve": [
+    "CVE-2018-12120"
+  ],
+  "vulnerable": "6",
+  "patched": "^6.15.0 || ^8.14.0",
+  "publish_date": "2018-11-27",
+  "author": "Ben Noordhuis",
+  "reported_by": "Ben Noordhuis",
+  "ref": "https://nodejs.org/en/blog/vulnerability/november-2018-security-releases/",
+  "type": "CWE-419: Unprotected Primary Channel",
+  "overview": "Debugger port 5858 listens on any interface by default: When the debugger is enabled with `node --debug` or `node debug`, it listens to port 5858 on all interfaces by default. This may allow remote computers to attach to the debug port and evaluate arbitrary JavaScript. The default interface is now localhost. It has always been possible to start the debugger on a specific interface, such as `node --debug=localhost`. The debugger was removed in Node.js 8 and replaced with the inspector, so no versions from 8 and later are vulnerable."
+}

--- a/vuln/core/57.json
+++ b/vuln/core/57.json
@@ -1,0 +1,13 @@
+{
+  "cve": [
+    "CVE-2018-12121"
+  ],
+  "vulnerable": "6 || 8 || 10 || 11",
+  "patched": "^6.15.0 || ^8.14.0 || ^10.14.0 || ^11.3.0",
+  "publish_date": "2018-11-27",
+  "author": "Matteo Collina",
+  "reported_by": "Trevor Norris",
+  "ref": "https://nodejs.org/en/blog/vulnerability/november-2018-security-releases/",
+  "type": "CWE-400: Uncontrolled Resource Consumption / Denial of Service",
+  "overview": "Denial of Service with large HTTP headers: By using a combination of many requests with maximum sized headers (almost 80 KB per connection), and carefully timed completion of the headers, it is possible to cause the HTTP server to abort from heap allocation failure. Attack potential is mitigated by the use of a load balancer or other proxy layer."
+}

--- a/vuln/core/58.json
+++ b/vuln/core/58.json
@@ -1,0 +1,13 @@
+{
+  "cve": [
+    "CVE-2018-12122"
+  ],
+  "vulnerable": "6 || 8 || 10 || 11",
+  "patched": "^6.15.0 || ^8.14.0 || ^10.14.0 || ^11.3.0",
+  "publish_date": "2018-11-27",
+  "author": "Matteo Collina",
+  "reported_by": "Jan Maybach",
+  "ref": "https://nodejs.org/en/blog/vulnerability/november-2018-security-releases/",
+  "type": "CWE-400: Uncontrolled Resource Consumption / Denial of Service",
+  "overview": "Slowloris HTTP Denial of Service: An attacker can cause a Denial of Service (DoS) by sending headers very slowly keeping HTTP or HTTPS connections and associated resources alive for a long period of time."
+}

--- a/vuln/core/59.json
+++ b/vuln/core/59.json
@@ -1,0 +1,13 @@
+{
+  "cve": [
+    "CVE-2018-12123"
+  ],
+  "vulnerable": "6 || 8 || 10 || 11",
+  "patched": "^6.15.0 || ^8.14.0 || ^10.14.0 || ^11.3.0",
+  "publish_date": "2018-11-27",
+  "author": "Matteo Collina",
+  "reported_by": "Martin Bajanik",
+  "ref": "https://nodejs.org/en/blog/vulnerability/november-2018-security-releases/",
+  "type": "CWE-115: Misinterpretation of Input",
+  "overview": "Hostname spoofing in URL parser for javascript protocol: If a Node.js application is using url.parse() to determine the URL hostname, that hostname can be spoofed by using a mixed case \"javascript:\" (e.g. \"javAscript:\") protocol (other protocols are not affected). If security decisions are made about the URL based on the hostname, they may be incorrect."
+}


### PR DESCRIPTION
Covers Node.js security releases:
 * 6.15.0
 * 8.14.0
 * 10.14.0
 * 11.3.0

Ref: https://nodejs.org/en/blog/vulnerability/november-2018-security-releases/

Added a new "reported_by" field, I'd love to get a record of attribution in these (helps drives the right kind of incentives).