### PR TITLE
add CVE-2018-14732 webpack-dev-server

### DIFF
--- a/vuln/npm/485.json
+++ b/vuln/npm/485.json
@@ -1,9 +1,10 @@
 {
   "id": 485,
-  "title": "Origin Validation Error",
+  "title": "Improper Input Validation",
   "overview": "An issue was discovered in lib/Server.js in webpack-dev-server before 3.1.6. Attackers are able to steal developer's code because the origin of requests is not checked by the WebSocket server, which is used for HMR (Hot Module Replacement). Anyone can receive the HMR message sent by the WebSocket server via a ws://127.0.0.1:8080/ connection from any origin.",
   "created_at": "2018-12-21",
-  "updated_at": "2018-12-26",
+  "updated_at": "2018-12-27",
+  "publish_date": "2018-12-27",
   "module_name": "webpack-dev-server",
   "cves": [
     "CVE-2018-14732"

--- a/vuln/npm/485.json
+++ b/vuln/npm/485.json
@@ -19,5 +19,6 @@
     "https://github.com/webpack/webpack-dev-server/releases/tag/v3.1.11"
   ],
   "cvss_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N",
-  "cvss_score": 7.5
+  "cvss_score": 7.5,
+  "coordinating_vendor": null
 }

--- a/vuln/npm/485.json
+++ b/vuln/npm/485.json
@@ -3,6 +3,7 @@
   "title": "Origin Validation Error",
   "overview": "An issue was discovered in lib/Server.js in webpack-dev-server before 3.1.6. Attackers are able to steal developer's code because the origin of requests is not checked by the WebSocket server, which is used for HMR (Hot Module Replacement). Anyone can receive the HMR message sent by the WebSocket server via a ws://127.0.0.1:8080/ connection from any origin.",
   "created_at": "2018-12-21",
+  "updated_at": "2018-12-26",
   "module_name": "webpack-dev-server",
   "cves": [
     "CVE-2018-14732"

--- a/vuln/npm/485.json
+++ b/vuln/npm/485.json
@@ -1,6 +1,6 @@
 {
-  "id": 484,
-  "title": "webpack-dev-server origin validation",
+  "id": 485,
+  "title": "Origin Validation Error",
   "overview": "An issue was discovered in lib/Server.js in webpack-dev-server before 3.1.6. Attackers are able to steal developer's code because the origin of requests is not checked by the WebSocket server, which is used for HMR (Hot Module Replacement). Anyone can receive the HMR message sent by the WebSocket server via a ws://127.0.0.1:8080/ connection from any origin.",
   "created_at": "2018-12-21",
   "module_name": "webpack-dev-server",

--- a/vuln/npm/new.json
+++ b/vuln/npm/new.json
@@ -1,0 +1,21 @@
+{
+  "id": 484,
+  "title": "webpack-dev-server origin validation",
+  "overview": "An issue was discovered in lib/Server.js in webpack-dev-server before 3.1.6. Attackers are able to steal developer's code because the origin of requests is not checked by the WebSocket server, which is used for HMR (Hot Module Replacement). Anyone can receive the HMR message sent by the WebSocket server via a ws://127.0.0.1:8080/ connection from any origin.",
+  "created_at": "2018-12-21",
+  "module_name": "webpack-dev-server",
+  "cves": [
+    "CVE-2018-14732"
+  ],
+  "vulnerable_versions": "<=3.1.10",
+  "patched_versions": ">=3.1.11",
+  "recommendation": "update webpack-dev-server to 3.1.11 or higher",
+  "references": [
+    "https://github.com/webpack/webpack-dev-server/commit/f18e5adf123221a1015be63e1ca2491ca45b8d10",
+    "https://github.com/webpack/webpack-dev-server/issues/1445",
+    "https://www.npmjs.com/advisories/725",
+    "https://github.com/webpack/webpack-dev-server/releases/tag/v3.1.11"
+  ],
+  "cvss_vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N",
+  "cvss_score": 7.5
+}


### PR DESCRIPTION
This relates to #460 

This adds [CVE-2018-14732](https://nvd.nist.gov/vuln/detail/CVE-2018-14732) into the database.
Also relates to https://www.npmjs.com/advisories/725.

- I left the `id` as `???`.  How does an ID get assigned to this correctly?
- I left many fields out that appear on other reports.  Happy to add other fields if they are needed.
