### PR TITLE
docs: removing year from license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 =====================
 
-Copyright (c) 2017 Node.js Foundation
+Copyright (c) Node.js Foundation
 -------------------------------------
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
Removing the year from the license file as to be consistent with the Node.js repo and per @Trott comments at https://github.com/nodejs/security-wg/pull/429#issuecomment-435193081