### PR TITLE
docs: update link in governance  document

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -115,5 +115,5 @@ closing vote or a vote to table the issue to the next meeting. The call for a
 vote must be seconded by a majority of the WG or else the discussion will
 continue. Simple majority wins.
 
-Note that changes to WG membership require unanimous consensus. See "WG
-Membership" above.
+Note that changes to WG membership require unanimous consensus. See [WG 
+Membership](#wg-membership).


### PR DESCRIPTION
Cosmetic clean-up to the docs. 
Supersedes https://github.com/nodejs/security-wg/pull/429 due to inactivity and PR changes required on the original one.