### PR TITLE
fix(NSWG-ECO-496): use CVE-2019-11358 instead of CVE-2019-5428

### DIFF
--- a/vuln/npm/496.json
+++ b/vuln/npm/496.json
@@ -12,6 +12,7 @@
   },
   "module_name": "jQuery",
   "cves": [
+    "CVE-2019-5428",
     "CVE-2019-11358"
   ],
   "vulnerable_versions": "<3.4.0",

--- a/vuln/npm/496.json
+++ b/vuln/npm/496.json
@@ -12,7 +12,7 @@
   },
   "module_name": "jQuery",
   "cves": [
-    "CVE-2019-5428"
+    "CVE-2019-11358"
   ],
   "vulnerable_versions": "<3.4.0",
   "patched_versions": ">=3.4.0",


### PR DESCRIPTION
ref. https://nvd.nist.gov/vuln/detail/CVE-2019-5428