### PR TITLE
Nominating André Eleuterio to join the Security WG

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ You can show your users you take security matters seriously and drive higher con
 
 ## Current Project Team Members
 
+* [aeleuterio](https://github.com/aeleuterio) **André Eleuterio**
 * [bengl](https://github.com/bengl) - **Bryan English**
 * [brycebaril](https://github.com/brycebaril) - **Bryce Baril**
 * [ChALkeR](https://github.com/ChALkeR) - **Сковорода Никита Андреевич**

--- a/processes/third_party_vuln_process.md
+++ b/processes/third_party_vuln_process.md
@@ -121,6 +121,7 @@ Vulnerabilities disclosed to this repository without using HackerOne currently c
 Members of the security teams should indicate that they accept the privacy policies
 by PRing their acceptance to this file:
 
+* @aeleuterio - André Eleuterio
 * @brycebaril - Bryce Baril
 * @cjihrig - Colin Ihrig
 * @dgonzalez - David Gonzalez


### PR DESCRIPTION
I have spoken to André Eleuterio ([twitter](https://twitter.com/eleuterio_), [linkedin](https://www.linkedin.com/in/andr%2525C3%2525A9-eleuterio-a4570a128), [npm](https://www.npmjs.com/~andreeleuterio)) and he would like to join the Security WG.

André triages vulnerabilities for NPM in both the npm tooling and ecosystem packages.

He is keen to join the Security WG and the vulnerability triage team.

Having a member of the NPM team, like André, will help coordinate efforts and communications.