### PR TITLE
docs(processes): upper vulnerable version policy

### DIFF
--- a/processes/third_party_vuln_process.md
+++ b/processes/third_party_vuln_process.md
@@ -62,6 +62,10 @@ the package has been patched.
 If the maintainers are unreachable, the vulnerability is to be made public
 45 days after the triage date.
 
+The report's upper limit of the vulnerable versions should be set to:
+* `*` if there is no fixed version available by the time of publishing the report. This is mostly in cases where the maintainer hasn't been able to take part in the triage process.
+* the version less than that which a fix exists for. For example: `<=1.2.3` if a fix exists in `1.2.4`
+
 ## Publication
 
 **Who:** A member of the triage team

--- a/processes/third_party_vuln_process.md
+++ b/processes/third_party_vuln_process.md
@@ -64,7 +64,7 @@ If the maintainers are unreachable, the vulnerability is to be made public
 
 The report's vulnerable versions upper limit should be set to:
 * `*` if there is no fixed version available by the time of publishing the report. This is mostly in cases where the maintainer hasn't taken part in the triage process.
-* the version less than that which a fix exists for. For example: `<=1.2.3` if a fix exists in `1.2.4`
+* the last vulnerable version. For example: `<=1.2.3` if a fix exists in `1.2.4`
 
 ## Publication
 

--- a/processes/third_party_vuln_process.md
+++ b/processes/third_party_vuln_process.md
@@ -63,7 +63,7 @@ If the maintainers are unreachable, the vulnerability is to be made public
 45 days after the triage date.
 
 The report's vulnerable versions upper limit should be set to:
-* `*` if there is no fixed version available by the time of publishing the report. This is mostly in cases where the maintainer hasn't been able to take part in the triage process.
+* `*` if there is no fixed version available by the time of publishing the report. This is mostly in cases where the maintainer hasn't taken part in the triage process.
 * the version less than that which a fix exists for. For example: `<=1.2.3` if a fix exists in `1.2.4`
 
 ## Publication

--- a/processes/third_party_vuln_process.md
+++ b/processes/third_party_vuln_process.md
@@ -62,7 +62,7 @@ the package has been patched.
 If the maintainers are unreachable, the vulnerability is to be made public
 45 days after the triage date.
 
-The report's upper limit of the vulnerable versions should be set to:
+The report's vulnerable versions upper limit should be set to:
 * `*` if there is no fixed version available by the time of publishing the report. This is mostly in cases where the maintainer hasn't been able to take part in the triage process.
 * the version less than that which a fix exists for. For example: `<=1.2.3` if a fix exists in `1.2.4`
 


### PR DESCRIPTION
Addresses https://github.com/nodejs/security-wg/issues/526 with regards to setting an upper version limit of * for all reports that do not have a fix when they get disclosed.