### PR TITLE
Correct semver range on vuln 457

### DIFF
--- a/vuln/npm/457.json
+++ b/vuln/npm/457.json
@@ -14,7 +14,7 @@
   "cves": [
     "CVE-2018-3778"
   ],
-  "vulnerable_versions": "<0.35.0",
+  "vulnerable_versions": "<=0.35.0",
   "patched_versions": ">=0.35.1",
   "recommendation": "Update aedes module to version >= 0.35.1",
   "references": [


### PR DESCRIPTION
@evilpacket I found this branch in the repo with unmerged changes.

It looks to me that it fixes an inconsistency: since `"patched_versions": ">=0.35.1"`, then it must be that `"vulnerable_versions": "<=0.35.0"`, but the existing JSON had `"vulnerable_versions": "<0.35.0"`.
