### PR TITLE
Remove names so that they can be re-PRed

### DIFF
--- a/processes/third_party_vuln_process.md
+++ b/processes/third_party_vuln_process.md
@@ -121,12 +121,10 @@ Vulnerabilities disclosed to this repository without using HackerOne currently c
 Members of the security teams should indicate that they accept the privacy policies
 by PRing their acceptance to this file:
 
-* @aeleuterio - André Eleuterio
 * @cjihrig - Colin Ihrig
 * @dgonzalez - David Gonzalez
 * @elexy - Alex Knol
 * @grnd - Danny Grander
-* @karenyavine - Karen Yavine Shemesh
 * @lirantal - Liran Tal
 * @MarcinHoppe - Marcin Hoppe
 * @pxlpnk - Andreas Tiefenthaler


### PR DESCRIPTION
These names were added during on-boarding, but not PRed by the specific
individual. The process (described here) is that the individual
personally PR their name onto the list to indicate acceptance of the
triage team policy.