### PR TITLE
docs(process): add hackerone staff contact

### DIFF
--- a/processes/third_party_vuln_process.md
+++ b/processes/third_party_vuln_process.md
@@ -134,6 +134,14 @@ policies by PRing their acceptance to this file:
 * @sam-github - Sam Roberts <vieuxtech@gmail.com>
 * @vdeturckheim - Vladimir de Turckheim
 
+# HackerOne Support Engineers
+
+Following contacts are officially assigned HackerOne support staff for the Node.js Ecosystem program:
+
+* Alek Relyea <alek at hackerone dot com>
+* Megan Mahowald <megan at hackerone dot com>
+# Reed Loden <reed at hackerone dot com>
+ 
 ### Emeritus Members
 
 * @bengl - Bryan English

--- a/processes/third_party_vuln_process.md
+++ b/processes/third_party_vuln_process.md
@@ -146,4 +146,4 @@ Following contacts are officially assigned HackerOne support staff for the Node.
 
 * Alek Relyea <alek at hackerone dot com>
 * Megan Mahowald <megan at hackerone dot com>
-* Reed Loden <reed at hackerone dot com>
+* Reed Loden @reedloden

--- a/processes/third_party_vuln_process.md
+++ b/processes/third_party_vuln_process.md
@@ -133,6 +133,12 @@ policies by PRing their acceptance to this file:
 * @ronperris - Ron Perris
 * @sam-github - Sam Roberts <vieuxtech@gmail.com>
 * @vdeturckheim - Vladimir de Turckheim
+ 
+### Emeritus Members
+
+* @bengl - Bryan English
+* @brycebaril - Bryce Baril
+* @gergelyke - Gergely Nemeth
 
 ## HackerOne Support Engineers
 
@@ -141,9 +147,3 @@ Following contacts are officially assigned HackerOne support staff for the Node.
 * Alek Relyea <alek at hackerone dot com>
 * Megan Mahowald <megan at hackerone dot com>
 * Reed Loden <reed at hackerone dot com>
- 
-### Emeritus Members
-
-* @bengl - Bryan English
-* @brycebaril - Bryce Baril
-* @gergelyke - Gergely Nemeth

--- a/processes/third_party_vuln_process.md
+++ b/processes/third_party_vuln_process.md
@@ -140,7 +140,7 @@ Following contacts are officially assigned HackerOne support staff for the Node.
 
 * Alek Relyea <alek at hackerone dot com>
 * Megan Mahowald <megan at hackerone dot com>
-# Reed Loden <reed at hackerone dot com>
+* Reed Loden <reed at hackerone dot com>
  
 ### Emeritus Members
 

--- a/processes/third_party_vuln_process.md
+++ b/processes/third_party_vuln_process.md
@@ -134,7 +134,7 @@ policies by PRing their acceptance to this file:
 * @sam-github - Sam Roberts <vieuxtech@gmail.com>
 * @vdeturckheim - Vladimir de Turckheim
 
-# HackerOne Support Engineers
+## HackerOne Support Engineers
 
 Following contacts are officially assigned HackerOne support staff for the Node.js Ecosystem program:
 


### PR DESCRIPTION
I found it relevant to provide contact information for H1 staff in attempt to make our triaging process more transparent and allow quickly reaching out to HackerOne contacts when issues happen.