### PR TITLE
process: correct Ben Noordhuis membership

### DIFF
--- a/processes/security_team_members.md
+++ b/processes/security_team_members.md
@@ -15,6 +15,7 @@ policies by PRing their acceptance to this file.
 
 ## Team that triages security reports against node core
 
+- @bnoordhuis - **Ben Noordhuis**
 - @cjihrig - **Colin Ihrig**
 - @indutny - **Fedor Indutny**
 - @jasnell - **James M Snell**
@@ -26,7 +27,6 @@ policies by PRing their acceptance to this file.
 
 ### Emeritus
 
-- @bnoordhuis - **Ben Noordhuis**
 - @jasnell - **James M Snell**
 - @shigeki - **Shigeki Ohtsu**
 


### PR DESCRIPTION
@bnoordhuis is listed as Emiriti, but he is still a member of all the
Node.js security teams in github, including the triage team. Reconcile
this by moving him back into the team, and inviting him to H1.

@bnoordhuis If you don't in fact want to be on the Node.js triage and security teams, please comment here, and I'll remove you from all the teams.

Otherwise, I'm reconciling by inviting you to the H1 team.