### PR TITLE
docs(processes): update downloads count based on npm

### DIFF
--- a/processes/third_party_vuln_submit_form_hacker1.md
+++ b/processes/third_party_vuln_submit_form_hacker1.md
@@ -17,9 +17,7 @@ It allows [DESCRIBE THE IMPACT OF THE VULNERABILITY - E.G READ ARBITRARY FILES, 
 
 > Replace stats below with numbers from npm’s module page:
 
-[1] downloads in the last day
-[10] downloads in the last week
-[100] downloads in the last month
+[X] weekly downloads 
 
 # Vulnerability
 


### PR DESCRIPTION
The npm pages don't include anymore the monthly and daily downloads, only the weekly downloads so I changed the form here to specify that. Once we approve I'll also make the same changes on the H1 Program for the vulnerability submission form 