### PR TITLE
Proposal to use CVSS v3.1

### DIFF
--- a/processes/third_party_triage_guidelines.md
+++ b/processes/third_party_triage_guidelines.md
@@ -42,10 +42,17 @@ Vulnerabilities that require users of a package to take an action, most often up
 
 Sometimes vulnerability resolutions are partial and do not fully resolve the underlying problem. It is encouraged to facilitate collaboration between the submitter and package maintainer to verify if the resolution is full and does not lead to further security problems.
 
+## How to score severity of vulnerabilities in libraries?
+
+Many npm packages are libraries. It is recommended to follow CVSS v3.1 [guidelines for scoring vulnerabilities in libraries](https://www.first.org/cvss/v3.1/user-guide#3-7-Scoring-Vulnerabilities-in-Software-Libraries-and-Similar).
+
 # References
 
 HackerOne Disclosure Guidelines
 https://www.hackerone.com/disclosure-guidelines
 
 CVE Counting Rules
-https://drive.google.com/file/d/1edCzKfsds79S6z411EJ5qQa-c6z2Bc4A/view 
+https://drive.google.com/file/d/1edCzKfsds79S6z411EJ5qQa-c6z2Bc4A/view
+
+CVSS v3.1
+https://www.first.org/cvss/v3.1/user-guide

--- a/processes/third_party_vuln_process.md
+++ b/processes/third_party_vuln_process.md
@@ -76,7 +76,7 @@ The report's vulnerable versions upper limit should be set to:
 
 Within 45 days after the triage date, the vulnerability must be made public.
 
-**Severity**: Vulnerability severity is assessed using [CVSS v.3](https://www.first.org/cvss/user-guide).
+**Severity**: Vulnerability severity is assessed using [CVSS v3.1](https://www.first.org/cvss/v3.1/user-guide).
 More information can be found on [HackerOne documentation](https://support.hackerone.com/hc/en-us/articles/213421106-How-does-HackerOne-recommend-determining-Severity-)
 
 If a patch is being actively developed by the package maintainer, an additional delay


### PR DESCRIPTION
So far our process documentation stated that we used CVSS v3 was the severity scoring system, most likely to explicitly state that we should not be using CVSS v2. Several weeks ago FIRST published CVSS v3.1 and I am proposing that we adopt it as our severity scoring system.

I think this will benefit us because of general improvements based on collective industry experience  of using CVSS v3, and also because of specific guidance for scoring severity of vulnerabilities in libraries (which is our dominant use case).

@nodejs/security-wg I'd love to get your feedback on the proposed change.