### PR TITLE
vuln: Node.js Feb 2020 security release

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -24,7 +24,7 @@ The `reporter` is a CLI tool to fetch the report data from HackerOne and output 
 From the main repository directory, the reporter can be invoked as follows and will default to interactive mode:
 
 ```bash
-$ npm run reporter -- --reportId <h1-report-id>
+$ npm run report -- --reportId <h1-report-id>
 ```
 
 Interactive-mode will kick in to prompt for the following NSWG report field which aren't fetched from HackerOne: NSWG Ecosystem Report ID, Vulnerable Versions, Patched Versions.

--- a/vuln/core/63.json
+++ b/vuln/core/63.json
@@ -2,7 +2,6 @@
   "cve": ["CVE-2019-15604"],
   "vulnerable": "10.x || 12.x || 13.x",
   "patched": "^10.19.0 || ^12.15.0 || ^13.8.0",
-  "author": "Sam Roberts",
   "reported_by": "Rogier Schouten",
   "ref": "https://hackerone.com/reports/746733",
   "overview": "Remotely trigger an assertion on a TLS server with a malformed certificate string"

--- a/vuln/core/63.json
+++ b/vuln/core/63.json
@@ -1,0 +1,9 @@
+{
+  "cve": ["CVE-2019-15604"],
+  "vulnerable": "10.x || 12.x || 13.x",
+  "patched": "^10.19.0 || ^12.15.0 || ^13.8.0",
+  "author": "Sam Roberts",
+  "reported_by": "Rogier Schouten",
+  "ref": "https://hackerone.com/reports/746733",
+  "overview": "Remotely trigger an assertion on a TLS server with a malformed certificate string"
+}

--- a/vuln/core/64.json
+++ b/vuln/core/64.json
@@ -1,0 +1,8 @@
+{
+  "cve": ["CVE-2019-15605"],
+  "vulnerable": "10.x || 12.x || 13.x",
+  "patched": "^10.19.0 || ^12.15.0 || ^13.8.0",
+  "reported_by": "Ethan Rubinson",
+  "ref": "https://hackerone.com/reports/735748",
+  "overview": "HTTP request smuggling using malformed Transfer-Encoding header"
+}

--- a/vuln/core/65.json
+++ b/vuln/core/65.json
@@ -1,0 +1,8 @@
+{
+  "cve": ["CVE-2019-15606"],
+  "vulnerable": "10.x || 12.x || 13.x",
+  "patched": "^10.19.0 || ^12.15.0 || ^13.8.0",
+  "reported_by": "Alyssa Wilk",
+  "ref": "https://hackerone.com/reports/730779",
+  "overview": "HTTP header values do not have trailing OWS trimmed"
+}


### PR DESCRIPTION
The JSON was created by `npm run report`, but they fail to validate.

I correct `cves` to `cve`, but then there was another error. I'm not sure, am I doing this wrong?