### PR TITLE
chore(member): add myself as new member

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ You can show your users you take security matters seriously and drive higher con
 
 * [ChALkeR](https://github.com/ChALkeR) - **Сковорода Никита Андреевич**
 * [cjihrig](https://github.com/cjihrig) - **Colin Ihrig**
+* [DanielRuf](https://github.com/DanielRuf) - **Daniel Ruf**
 * [dgonzalez](https://github.com/dgonzalez) - **David Gonzalez**
 * [deian](https://github.com/deian) - **Deian Stefan**
 * [grnd](https://github.com/grnd) - **Danny Grander**

--- a/processes/third_party_vuln_process.md
+++ b/processes/third_party_vuln_process.md
@@ -127,6 +127,7 @@ as the [Node.js Security Team](https://github.com/nodejs/security-wg/blob/master
 Members of the security teams should indicate that they accept the privacy
 policies by PRing their acceptance to this file:
 
+* @DanielRuf - Daniel Ruf
 * @grnd - Danny Grander
 * @karenyavine - Karen Yavine Shemesh
 * @lirantal - Liran Tal


### PR DESCRIPTION
I hereby accept the nomination in #614 and propose the following
addition to the Security WG members list and especially to the Ecosystem
Triage team.

I have read and understood all processes files and the rules outlined in
the Code of Conduct document.

@lirantal is my buddy who leads me through the on-boarding process.