### PR TITLE
Update the offboarding procedure

### DIFF
--- a/processes/wg_offboarding.md
+++ b/processes/wg_offboarding.md
@@ -16,8 +16,8 @@ At any time until the last time mark any member can chime in and request to reta
 ## Revoking Access to Confidential Systems
 
 The following is a check-list of actions to be taken upon departure of users from the Security WG (either voluntarily or due to inactivity as described above):
-* [ ] Remove user from [Repo README](https://github.com/nodejs/security-wg/blob/master/README.md), [Triage Team](https://github.com/nodejs/security-wg/blob/master/processes/third_party_vuln_process.md), [Security Team List](https://github.com/nodejs/security-wg/blob/master/processes/security_team_members.md), [GitHub CodeOwners](https://github.com/nodejs/security-wg/blob/master/.github/CODEOWNERS), 
-* [ ] Remove membership from [Node.js WG GitHub Team](https://github.com/orgs/nodejs/teams/security-wg) and [Triage GitHub Team](https://github.com/orgs/nodejs/teams/ecosystem-security)
+* [ ] Remove user from [Repo README](https://github.com/nodejs/security-wg/blob/master/README.md), [Triage Team](https://github.com/nodejs/security-wg/blob/master/processes/third_party_vuln_process.md)
+* [ ] Remove membership from [Node.js WG GitHub Team](https://github.com/orgs/nodejs/teams/security-wg)
 * [ ] Remove user from [HackerOne platform](hackerone.com/nodejs-ecosystem)
 * [ ] Revoke any user-specific access tokens from HackerOne platform
 * [ ] Remove user access from private team channels in slack (nodejs-security-wg.slack.com)
@@ -25,7 +25,6 @@ The following is a check-list of actions to be taken upon departure of users fro
 The following is a check-list of actions to be taken upon voluntary departure of users from the [Third-Party Triage Team](https://github.com/nodejs/security-wg/blob/master/processes/third_party_vuln_process.md), when the users will remain in the Security WG.
 
 * [ ] Remove user from [Triage Team](https://github.com/nodejs/security-wg/blob/master/processes/third_party_vuln_process.md)
-* [ ] Remove membership from [Triage GitHub Team](https://github.com/orgs/nodejs/teams/ecosystem-security)
 * [ ] Remove user from [HackerOne platform](hackerone.com/nodejs-ecosystem)
 * [ ] Revoke any user-specific access tokens from HackerOne platform
 * [ ] Remove user access from private team channels in slack that are specific to the Triage Team (nodejs-security-wg.slack.com)


### PR DESCRIPTION
We offboarded some members of this WG after membership reviews (#591 and #632). The offboarding procedure was a bit out of date as not all referenced entities (GotHub teams, user lists and files) exist.

This PR updates the offboarding procedure so that it can be accurately followed the next time we need to offboard a WG member.