### PR TITLE
docs: add meeting notes 2020-05-18

### DIFF
--- a/meetings/2020-05-18.md
+++ b/meetings/2020-05-18.md
@@ -2,7 +2,7 @@
 
 ## Links
 
-* **Recording**:  
+* **Recording**: https://www.youtube.com/watch?v=2TsR4kjrRVI 
 * **GitHub Issue**: https://github.com/nodejs/security-wg/issues/656
 * **Minutes Google Doc**: https://docs.google.com/document/d/1OcSWUlYPuxR4mKqpulKW99PaIXBt0L5AQ8ZI9hOJ5oI/edit
 

--- a/meetings/2020-05-18.md
+++ b/meetings/2020-05-18.md
@@ -1,0 +1,39 @@
+# Node.js  Security WorkGroup Meeting 2020-05-18
+
+## Links
+
+* **Recording**:  
+* **GitHub Issue**: https://github.com/nodejs/security-wg/issues/656
+* **Minutes Google Doc**: https://docs.google.com/document/d/1OcSWUlYPuxR4mKqpulKW99PaIXBt0L5AQ8ZI9hOJ5oI/edit
+
+## Present
+
+* Security wg team: @nodejs/security-wg
+* @sam-github
+* @lirantal
+
+
+## Agenda
+
+## Announcements
+
+### nodejs/security-wg
+
+* https://github.com/nodejs/security-wg/issues/614 - Agreed to onboard Daniel.
+* https://github.com/nodejs/security-wg/issues/628 - No objections, we should complete moving DB to security-advisories repo, then change the name.
+* https://github.com/nodejs/security-wg/pull/627 - Liran will reach out to confirm that Matt is still interested, and if so, will merge the PR, will be good to have more triagers.
+* https://github.com/nodejs/security-wg/issues/626 - Need Vladimir to review but basically this sounds like a Node.js core issue we should open and tag the security-wg for interest conversation
+* https://github.com/nodejs/security-wg/issues/511 - We’ll ping some folks to get involved but no actionable item to take on this at the moment.
+* https://github.com/nodejs/security-wg/issues/604 - Taking actions on this:
+1. Update the policies (triage process, program page, security.md for the nodejs website, github.com/nodejs/node/security.md) for the updated threshold.
+2. Are we all agreeing on the threshold of 10000 monthly downloads as an eligible module for us?
+* https://github.com/nodejs/security-wg/issues/657
+
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar.


### PR DESCRIPTION
Fixes https://github.com/nodejs/security-wg/issues/656

@sam-github I need the youtube video URL of the recording once it's live to update in the meeting notes