### PR TITLE
docs: fix some broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Table of Contents
   * [Recognition for Security Researchers](./processes/recognition.md)
 - Processes for Security WG Members
   * [Security Team Membership Policy](./processes/security_team_membership_policy.md)
-  * [On-boarding Team Members](./processes/security_team_onboarding.md)
-  * [Off-boarding Team Members](./processes/security_team_offboarding.md)
+  * [On-boarding Team Members](./processes/wg_onboarding.md)
+  * [Off-boarding Team Members](./processes/wg_offboarding.md)
 - [Node.js Bug Bounty Program](#nodejs-bug-bounty-program)
 - [Participate in Responsible Security Disclosure](#participate-in-responsible-security-disclosure)
 - [Charter](#charter)

--- a/processes/third_party_vuln_process.md
+++ b/processes/third_party_vuln_process.md
@@ -42,7 +42,7 @@ Triaging should include updating issue fields:
 * Asset - set/create the module affected by the report
 * Severity - TBD, currently left empty
 
-Reference: [HackerOne: How do I triage a report?](https://support.hackerone.com/hc/en-us/articles/205624715-How-do-I-triage-a-Report-)
+Reference: [HackerOne: Submitting Reports](https://docs.hackerone.com/hackers/submitting-reports.html)
 
 ### Correction follow-up
 
@@ -77,7 +77,7 @@ The report's vulnerable versions upper limit should be set to:
 Within 45 days after the triage date, the vulnerability must be made public.
 
 **Severity**: Vulnerability severity is assessed using [CVSS v.3](https://www.first.org/cvss/user-guide).
-More information can be found on [HackerOne documentation](https://support.hackerone.com/hc/en-us/articles/213421106-How-does-HackerOne-recommend-determining-Severity-)
+More information can be found on [HackerOne documentation](https://docs.hackerone.com/hackers/severity.html)
 
 If a patch is being actively developed by the package maintainer, an additional delay
 can be added with the approval of the triage team and the individual who
@@ -85,14 +85,14 @@ reported the vulnerability (this is a simple vote where each member of the
 triage team and the vulnerability reporter have 1 vote each).
 
 At this point, a CVE should be requested through the HackerOne platform through
-[email](cve-assign@hackerone.com) that should include the Report ID and a summary.
+[email](mailto:cve-assign@hackerone.com) that should include the Report ID and a summary.
 
 The vulnerability is considered as published when a Pull Request adding it
 to this repository is opened.
 
 Within HackerOne, this is handled through a "public disclosure request".
 
-Reference: [HackerOne: How does public disclosure work?](https://support.hackerone.com/hc/en-us/articles/205269479-How-does-public-disclosure-work-)
+Reference: [HackerOne: Disclosure](https://docs.hackerone.com/hackers/disclosure.html)
 
 ## Vulnerabilities found outside this process
 
@@ -120,7 +120,7 @@ Each member of the triage team is expected to handle vulnerabilities on a
 regular basis.
 
 Members of this team are required to follow the same NDA and privacy measures
-as the [Node.js Security Team](https://github.com/nodejs/security-wg/blob/master/processes/security_team_members.md).
+as the [Node.js Security Team](https://github.com/nodejs/security-wg#current-project-team-members).
 
 ### Members
 

--- a/processes/wg_offboarding.md
+++ b/processes/wg_offboarding.md
@@ -16,9 +16,9 @@ At any time until the last time mark any member can chime in and request to reta
 ## Revoking Access to Confidential Systems
 
 The following is a check-list of actions to be taken upon departure of users from the Security WG (either voluntarily or due to inactivity as described above):
-* [ ] Remove user from [Repo README](https://github.com/nodejs/security-wg/blob/master/README.md), [Triage Team](https://github.com/nodejs/security-wg/blob/master/processes/third_party_vuln_process.md), [Security Team List](https://github.com/nodejs/security-wg/blob/master/processes/security_team_members.md), [GitHub CodeOwners](https://github.com/nodejs/security-wg/blob/master/.github/CODEOWNERS), 
+* [ ] Remove user from [Repo README](https://github.com/nodejs/security-wg/blob/master/README.md), [Triage Team](https://github.com/nodejs/security-wg/blob/master/processes/third_party_vuln_process.md), [Security Team List](https://github.com/nodejs/security-wg#current-project-team-members), [GitHub CodeOwners](https://github.com/nodejs/security-wg/blob/master/.github/CODEOWNERS), 
 * [ ] Remove membership from [Node.js WG GitHub Team](https://github.com/orgs/nodejs/teams/security-wg) and [Triage GitHub Team](https://github.com/orgs/nodejs/teams/ecosystem-security)
-* [ ] Remove user from [HackerOne platform](hackerone.com/nodejs-ecosystem)
+* [ ] Remove user from [HackerOne platform](https://hackerone.com/nodejs-ecosystem)
 * [ ] Revoke any user-specific access tokens from HackerOne platform
 * [ ] Remove user access from private team channels in slack (nodejs-security-wg.slack.com)
 
@@ -26,6 +26,6 @@ The following is a check-list of actions to be taken upon voluntary departure of
 
 * [ ] Remove user from [Triage Team](https://github.com/nodejs/security-wg/blob/master/processes/third_party_vuln_process.md)
 * [ ] Remove membership from [Triage GitHub Team](https://github.com/orgs/nodejs/teams/ecosystem-security)
-* [ ] Remove user from [HackerOne platform](hackerone.com/nodejs-ecosystem)
+* [ ] Remove user from [HackerOne platform](https://hackerone.com/nodejs-ecosystem)
 * [ ] Revoke any user-specific access tokens from HackerOne platform
 * [ ] Remove user access from private team channels in slack that are specific to the Triage Team (nodejs-security-wg.slack.com)


### PR DESCRIPTION
This PR fixes some broken links that I have found during my onboarding process and that I have checked with https://github.com/tcort/markdown-link-check today.

I am not sure what we have to do with `Security Team Membership Policy` in README.md as this leads to https://github.com/nodejs/security-wg/blob/master/processes/security_team_membership_policy.md

It was moved in the past and then it vanished: https://github.com/nodejs/security-wg/commit/13281e1cad262c2864aefba81239371ec12c79ac