### PR TITLE
fix: missing cvss vector for 443

### DIFF
--- a/vuln/npm/443.json
+++ b/vuln/npm/443.json
@@ -18,7 +18,7 @@
   "references": [
     "https://hackerone.com/reports/321704"
   ],
-  "cvss_vector": "CVSS:3.0/AV:U/AC:U/PR:U/UI:U/S:U/C:U/I:U/A:U",
+  "cvss_vector": "CVSS:3.0/AV:L/AC:H/PR:H/UI:R/S:U/C:L/I:N/A:N",
   "cvss_score": 1.8,
   "coordinating_vendor": null
 }


### PR DESCRIPTION
Fix missing CVSS vector, as noted here: https://github.com/nodejs/security-wg/issues/703