### PR TITLE
fix: missing cvss vector for 446

### DIFF
--- a/vuln/npm/446.json
+++ b/vuln/npm/446.json
@@ -18,7 +18,7 @@
   "references": [
     "https://hackerone.com/reports/310671"
   ],
-  "cvss_vector": "CVSS:3.0/AV:U/AC:U/PR:U/UI:U/S:U/C:U/I:U/A:U",
+  "cvss_vector": "CVSS:3.0/AV:N/AC:L/PR:L/UI:R/S:U/C:L/I:N/A:N",
   "cvss_score": 3.5,
   "coordinating_vendor": null
 }


### PR DESCRIPTION
Fix missing CVSS vector, as noted here: #703

