### PR TITLE
Feat: Added OSSF scorecard reporting

### DIFF
--- a/.github/workflows/ossf-scorecard-reporting.yml
+++ b/.github/workflows/ossf-scorecard-reporting.yml
@@ -1,0 +1,31 @@
+name: "Nodejs Org - OSSF Scorecard Scoring"
+on: 
+  # Scheduled trigger
+  schedule:
+    - cron: "0 0 * * *"
+  # Manual trigger
+  workflow_dispatch:
+
+# Permissions required to run this workflow (create issue and commit/push changes)
+permissions:
+  contents: write
+  pull-requests: none 
+  issues: write
+  packages: none
+
+jobs:
+  security-scoring:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: OpenSSF Scorecard Monitor
+        uses: UlisesGascon/openssf-scorecard-monitor@v1.0.1
+        with:
+          scope: tools/ossf_scorecard/scope.json
+          database: tools/ossf_scorecard/database.json
+          report: tools/ossf_scorecard/report.md
+          auto-commit: true
+          auto-push: true
+          generate-issue: true
+          issue-title: "OpenSSF Scorecard Report Updated!"
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/tools/ossf_scorecard/scope.json
+++ b/tools/ossf_scorecard/scope.json
@@ -1,0 +1,12 @@
+{
+    "github.com": [{
+        "org": "nodejs",
+        "repo": "undici"
+    }, {
+        "org": "nodejs",
+        "repo": "node"
+    },{
+        "org": "nodejs",
+        "repo": "security-wg"
+    }]
+}


### PR DESCRIPTION
[As agreed](https://www.youtube.com/watch?v=HAqMRXb9aw4&t=1968s) here is the pipeline to run the scorecard analysis MVP for three projects (node, undici and security-wg). I created the folder `tools/ossf_scorecard/` to store the data related (`database.json`, `scope.json` and the report).

Side note: I mapped the feedback from the call in [this milestone](https://github.com/UlisesGascon/openssf-scorecard-monitor/milestone/1). I will create a separate PR once the version 2 is available with the hashes and auto-scoping 👍  