### PR TITLE
fix: skip validation on index.json

### DIFF
--- a/tools/vuln_valid/vulnValidate.js
+++ b/tools/vuln_valid/vulnValidate.js
@@ -124,6 +124,8 @@ function validateVuln(filePath, model) {
 function validate(dir, model) {
  const files = fs.readdirSync(dir);
   for (const name of files) {
+    // skip index.json validation
+    if (name === 'index.json') continue;
     const filePath = path.join(dir, name);
     validateVuln(filePath, model);
   }


### PR DESCRIPTION
validateVuln only works with id.json. There's no need to validate the index.json file.