### PR TITLE
ci: workflows permissions hardening

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,12 @@ on:
   schedule:
   - cron: "0 0 * * *"
 
+permissions:
+  # Needed to write a stale message on issues
+  issues: write
+  # Needed to close a stale pull-request
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-vulnerability.yml
+++ b/.github/workflows/validate-vulnerability.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'vuln/**/*.json'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hello 👋

I'm starting to look at improving the security issues in relation to the scorecard. One of the issue is the lack of top level permissions in our workflows.

> **Note** Github documentation about jobs permissions: [Assigning permissions to jobs](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)

I updated permissions for all workflows, however I had doubt for `update-core-index` and `update-npm-index`.

- Stale: I followed the [recommendations](https://github.com/actions/stale#recommended-permissions) for `actions/stale@v5`.
- Validate vulnerability: `contents` read is from what I see from my own projects enough to run Node/npm scripts.

This is a first step.


