### PR TITLE
chore: Add Dependabot for NPM and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    versioning-strategy: widen
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Copied over from https://github.com/nodejs/remark-preset-lint-node/blob/main/.github/dependabot.yml to address https://github.com/nodejs/security-wg/pull/886#discussion_r1116367408