### PR TITLE
feat: added affectedEnvironments to the core model

### DIFF
--- a/tools/vuln_valid/vulnValidate.js
+++ b/tools/vuln_valid/vulnValidate.js
@@ -34,7 +34,7 @@ const coreModel = joi.object().keys({
   reported_by: joi.string().optional(),
   affectedEnvironments: joi
   .array()
-  .items(joi.string().valid("osx", "win", "linux"))
+  .items(joi.string().valid("all", "osx", "win", "linux"))
   .min(1)
   .required()
 });

--- a/tools/vuln_valid/vulnValidate.js
+++ b/tools/vuln_valid/vulnValidate.js
@@ -34,7 +34,7 @@ const coreModel = joi.object().keys({
   reported_by: joi.string().optional(),
   affectedEnvironments: joi
   .array()
-  .items(joi.string().valid("mac", "win", "linux"))
+  .items(joi.string().valid("osx", "win", "linux"))
   .min(1)
 });
 

--- a/tools/vuln_valid/vulnValidate.js
+++ b/tools/vuln_valid/vulnValidate.js
@@ -31,7 +31,11 @@ const coreModel = joi.object().keys({
   type: joi.string().optional(),
   cvss_score: joi.number().optional(),
   cvss: joi.string().optional(),
-  reported_by: joi.string().optional()
+  reported_by: joi.string().optional(),
+  affectedEnvironments: joi
+  .array()
+  .items(joi.string().valid("mac", "win", "linux"))
+  .min(1)
 });
 
 const npmModel = joi.object().keys({

--- a/tools/vuln_valid/vulnValidate.js
+++ b/tools/vuln_valid/vulnValidate.js
@@ -36,6 +36,7 @@ const coreModel = joi.object().keys({
   .array()
   .items(joi.string().valid("osx", "win", "linux"))
   .min(1)
+  .required()
 });
 
 const npmModel = joi.object().keys({

--- a/tools/vuln_valid/vulnValidate.js
+++ b/tools/vuln_valid/vulnValidate.js
@@ -34,7 +34,8 @@ const coreModel = joi.object().keys({
   reported_by: joi.string().optional(),
   affectedEnvironments: joi
   .array()
-  .items(joi.string().valid("all", "osx", "win", "linux", "smartos", "aix", "freebsd"))
+  // See: https://nodejs.org/api/os.html#osplatform
+  .items(joi.string().valid("all", "aix", "darwin", "freebsd", "linux", "openbsd", "sunos", "win32", "android"))
   .min(1)
   .required()
 });

--- a/tools/vuln_valid/vulnValidate.js
+++ b/tools/vuln_valid/vulnValidate.js
@@ -34,7 +34,7 @@ const coreModel = joi.object().keys({
   reported_by: joi.string().optional(),
   affectedEnvironments: joi
   .array()
-  .items(joi.string().valid("all", "osx", "win", "linux"))
+  .items(joi.string().valid("all", "osx", "win", "linux", "smartos", "aix", "freebsd"))
   .min(1)
   .required()
 });


### PR DESCRIPTION
### Main changes

Added optional field`affectedEnvironments` to the core model in the vuln DB with `win`, `mac` and `linux` as possible values.

### Context
This was requested in: https://github.com/RafaelGSS/is-my-node-vulnerable/issues/9