### PR TITLE
Fix: broken pipeline permissions

### DIFF
--- a/.github/workflows/update-core-index.yml
+++ b/.github/workflows/update-core-index.yml
@@ -7,7 +7,8 @@ on:
       - 'vuln/core/*.json'
       - '!vuln/core/index.json'
 
-permissions: [read, write]
+permissions:
+  contents: write
 
 jobs:
   stale:

--- a/.github/workflows/update-npm-index.yml
+++ b/.github/workflows/update-npm-index.yml
@@ -7,7 +7,8 @@ on:
       - 'vuln/npm/*.json'
       - '!vuln/npm/index.json'
 
-permissions: [read, write]
+permissions:
+  contents: write
 
 jobs:
   stale:


### PR DESCRIPTION
### Main changes

Solves the permission definition in the pipelines as the syntax is currently wrong. [See](https://github.com/nodejs/security-wg/actions/runs/4212420570)

Side note: these workflow might not work as they need to write in a protected brach, related to #908