### PR TITLE
ci: Remove old Travis-CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-
-node_js:
-  - lts/*
-
-script:
-  - npm test
-  - npm run validate


### PR DESCRIPTION
Hook no longer appears to be used