### PR TITLE
Fix: npm index generation

### DIFF
--- a/tools/create_index/index_generator.js
+++ b/tools/create_index/index_generator.js
@@ -14,7 +14,7 @@ const supportedVersions = ['14.0.0', '16.0.0', '18.0.0', '19.0.0']
 
 const supportedVersionAffected = function (json) {
   for (const version of supportedVersions) {
-    if (satisfies(version, json.vulnerable)) {
+    if (!json.vulnerable || satisfies(version, json.vulnerable)) {
       return true
     }
   }


### PR DESCRIPTION
### Main changes

The npm index is generated empty. This change will fix that as make optional the validation against specific Node.js versions as only core vuln has that property in the reports.

### Context
Related: https://github.com/nodejs/security-wg/pull/918#issue-1631417210