### PR TITLE
Allow only manual trigger for OpenSSF Reporting tool

### DIFF
--- a/.github/workflows/ossf-scorecard-reporting.yml
+++ b/.github/workflows/ossf-scorecard-reporting.yml
@@ -1,10 +1,7 @@
 name: "OpenSSF Scoring"
 on: 
-  # Scheduled trigger
-  schedule:
-    # Run every Sunday at 00:00
-    - cron: "0 0 * * 0"
-  # Manual trigger
+  # TODO: Restore CRON trigger once https://github.com/nodejs/security-wg/issues/908 is closed
+  # Manual trigger 
   workflow_dispatch:
 
 # Permissions required to run this workflow (create issue and commit/push changes)


### PR DESCRIPTION
As agreed in #949 this change will prevent the Reporting to run several times between the meetings.

I decided that the manual trigger is the best option as I can control the execution time better. As well I can attach a simple root cost analysis to the PR if there are changes, so it is easier to follow during the meetings.

The CRON job will be restored once #908 is solved and this process won't require manual steps.