### PR TITLE
Upgrade openssf-scorecard-monitor to v2.0.0-beta4

### DIFF
--- a/.github/workflows/ossf-scorecard-reporting.yml
+++ b/.github/workflows/ossf-scorecard-reporting.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.3.0
       - name: OpenSSF Scorecard Monitor
-        uses: UlisesGascon/openssf-scorecard-monitor@e3526f91e57a02356942f85cd3da95ead823d28e # v2.0.0-beta2
+        uses: UlisesGascon/openssf-scorecard-monitor@1e297bbead0a526b3b70133c62b4a188a4f1776b # v2.0.0-beta4
         with:
           scope: tools/ossf_scorecard/scope.json
           database: tools/ossf_scorecard/database.json


### PR DESCRIPTION
### Main changes

The version `v.2.0.0-beta4` includes a new visualization tool that is using the API results directly. This was discussed in #945

### Context

- https://github.com/UlisesGascon/openssf-scorecard-monitor/releases/tag/v2.0.0-beta4
- https://github.com/UlisesGascon/openssf-scorecard-monitor/releases/tag/v2.0.0-beta3