### PR TITLE
chore: upgraded OpenSSF scorecard monitor version

### DIFF
--- a/.github/workflows/ossf-scorecard-reporting.yml
+++ b/.github/workflows/ossf-scorecard-reporting.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.3.0
       - name: OpenSSF Scorecard Monitor
-        uses: UlisesGascon/openssf-scorecard-monitor@1e297bbead0a526b3b70133c62b4a188a4f1776b # v2.0.0-beta4
+        uses: UlisesGascon/openssf-scorecard-monitor@2a02b95ef5958a65bb1b69ae0ac748da80307407 # v2.0.0-beta5
         with:
           scope: tools/ossf_scorecard/scope.json
           database: tools/ossf_scorecard/database.json


### PR DESCRIPTION
### Main changes
The version `v.2.0.0-beta5` includes commit hash for immutable scorecard reports. This was discussed in https://github.com/nodejs/security-wg/issues/961

### Context
- https://github.com/KoolTheba/openssf-scorecard-api-visualizer/issues/34
- https://github.com/UlisesGascon/openssf-scorecard-monitor/releases/tag/v2.0.0-beta5