### PR TITLE
chore: upgraded OpenSSF scorecard monitor version

### DIFF
--- a/.github/workflows/ossf-scorecard-reporting.yml
+++ b/.github/workflows/ossf-scorecard-reporting.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.3.0
       - name: OpenSSF Scorecard Monitor
-        uses: UlisesGascon/openssf-scorecard-monitor@2a02b95ef5958a65bb1b69ae0ac748da80307407 # v2.0.0-beta5
+        uses: UlisesGascon/openssf-scorecard-monitor@d52f37a10a1c73bc1604cd07b7032102518e8460 # v2.0.0-beta6
         with:
           scope: tools/ossf_scorecard/scope.json
           database: tools/ossf_scorecard/database.json


### PR DESCRIPTION
### Main changes
The `v.2.0.0-beta6` release introduces the innovative OpenSSF Scorecard Monitor Visualizer Comparator, an advanced functionality that seamlessly compares OpenSSF scorecards between different commits. 

Explore this powerful feature through the provided example, where a comprehensive analysis is conducted by comparing the latest reported commit of the scorecard with the most recent commit discussed during a meeting (as mentioned at: https://github.com/nodejs/security-wg/issues/994). 

Visit the following [link](https://kooltheba.github.io/openssf-scorecard-api-visualizer/#/projects/github.com/nodejs/node/compare/d2a1f71c3e202b23c90daf86bda262f244ce517a/fdf8ecde9e57636314247791d67df374f762382e) for a live demo 🚀.


### Context
- https://github.com/UlisesGascon/openssf-scorecard-monitor/releases/tag/v2.0.0-beta6