### PR TITLE
Update the OSSF Monitor exclusion list

### DIFF
--- a/tools/ossf_scorecard/scope.json
+++ b/tools/ossf_scorecard/scope.json
@@ -6,7 +6,6 @@
         "node-gyp",
         "nan",
         "build",
-        "node-addon-examples",
         "diagnostics",
         "node",
         "docker-node",
@@ -15,7 +14,6 @@
         "nodejs.org",
         "citgm",
         "TSC",
-        "help",
         "llnode",
         "core-validate-commit",
         "nodejs-nightly-builder",
@@ -41,10 +39,12 @@
         "node-auto-test"
       ],
       "excluded": [
+        "node-addon-examples",
         "nodejs.dev",
         "modules",
         "i18n",
         "nodejs-ko",
+        "help",
         "http-parser",
         "mentorship",
         "node-inspect",


### PR DESCRIPTION
Excluded `nodejs/help` and `nodejs/node-addon-examples`.

This will help us to remove the noise in the reports 🙌 