### PR TITLE
CII Passing: add commit hash reference for the context links

### DIFF
--- a/tools/ossf_best_practices/passing_criteria.md
+++ b/tools/ossf_best_practices/passing_criteria.md
@@ -7,7 +7,7 @@ Check the official [report](https://bestpractices.coreinfrastructure.org/en/proj
 **Node.js**
 
 Context:
-- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#basics)
+- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#basics)
 
 
 > What is a brief description of the project?
@@ -15,35 +15,35 @@ Context:
 **Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine**
 
 Context:
-- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#basics)
+- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#basics)
 
 > What is the URL for the project (as a whole)?
 
 **https://nodejs.org**
 
 Context:
-- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#basics)
+- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#basics)
 
 > What is the URL for the version control repository (it may be the same as the project URL)?
 
 **https://github.com/nodejs/node**
 
 Context:
-- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#basics)
+- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#basics)
 
 > What programming language(s) are used to implement the project? 
 
 **JavaScript, C++, Python (CII estimate)**
 
 Context:
-- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#basics)
+- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#basics)
 
 > What is the [Common Platform Enumeration (CPE)](https://nvd.nist.gov/cpe.cfm) name for the project (if it has one)? 
 
 **`cpe:2.3:a:nodejs:node.js:*:*:*:*:-:*:*:*`**
 
 Context:
-- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#basics)
+- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#basics)
 - [Team discussion](https://github.com/nodejs/security-wg/pull/954#discussion_r1197621966)
 
 ## Basic project website content
@@ -53,14 +53,14 @@ Context:
 **Met**
 
 Context:
-- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#basics)
+- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#basics)
 
 > The project website MUST provide information on how to: obtain, provide feedback (as bug reports or enhancements), and contribute to the software.
 
 **Met. https://nodejs.org/en/get-involved**
 
 Context:
-- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#basics)
+- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#basics)
 
 
 > The information on how to contribute MUST explain the contribution process (e.g., are pull requests used?) (URL required)
@@ -68,14 +68,14 @@ Context:
 **Met. https://github.com/nodejs/node/blob/master/CONTRIBUTING.md**
 
 Context:
-- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#basics)
+- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#basics)
 
 > The information on how to contribute SHOULD include the requirements for acceptable contributions (e.g., a reference to any required coding standard). (URL required)
 
 **Met. https://github.com/nodejs/node/blob/master/CONTRIBUTING.md**
 
 Context:
-- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#basics)
+- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#basics)
 
 
 ## FLOSS license
@@ -85,23 +85,23 @@ Context:
 **Met**
 
 Context:
-- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#basics)
-- [CII Best practices: FLOSS license](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#floss_license)
+- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#basics)
+- [CII Best practices: FLOSS license](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#floss_license)
 
 > It is SUGGESTED that any required license(s) for the software produced by the project be approved by the Open Source Initiative (OSI).
 
 **Met**
 
 Context:
-- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#basics)
+- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#basics)
 
 > The project MUST post the license(s) of its results in a standard location in their source repository. (URL required)
 
 **Met. https://github.com/nodejs/node/blob/master/LICENSE**
 
 Context:
-- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#basics)
-- [CII Best Practices: License Location](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#license_location)
+- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#basics)
+- [CII Best Practices: License Location](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#license_location)
 
 ## Documentation
 
@@ -110,16 +110,16 @@ Context:
 **Met. https://nodejs.org/en/docs/**
 
 Context:
-- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#basics)
-- [CII Best Practices: Documentation Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#documentation_basics)
+- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#basics)
+- [CII Best Practices: Documentation Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#documentation_basics)
 
 > The project MUST provide reference documentation that describes the external interface (both input and output) of the software produced by the project.
 
 **Met. https://nodejs.org/api/**
 
 Context:
-- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#basics)
-- [CII Best Practices: Documentation Interface](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#documentation_interface)
+- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#basics)
+- [CII Best Practices: Documentation Interface](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#documentation_interface)
 
 ## Other
 
@@ -128,29 +128,29 @@ Context:
 **Met**
 
 Context:
-- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#basics)
-- [CII Best Practices: Sites HTTPS](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#sites_https)
+- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#basics)
+- [CII Best Practices: Sites HTTPS](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#sites_https)
 
 > The project MUST have one or more mechanisms for discussion (including proposed changes and issues) that are searchable, allow messages and topics to be addressed by URL, enable new people to participate in some of the discussions, and do not require client-side installation of proprietary software.
 
 **Met. GitHub issue tracker and pull requests support discussion**
 
 Context:
-- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#basics)
+- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#basics)
 
 > The project SHOULD provide documentation in English and be able to accept bug reports and comments about code in English. 
 
 **Met**
 
 Context:
-- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#basics)
+- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#basics)
 
 > The project MUST be maintained.
 
 **Met**
 
 Context:
-- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#basics)
+- [CII Best Practices: Criteria Basics](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#basics)
 
 # Change Control
 
@@ -161,31 +161,31 @@ Context:
 **Met**
 
 Context:
-- [CII Best Practices: Change Control](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#change-control)
-- [CII Best Practices: Repo Public](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#repo_public)
+- [CII Best Practices: Change Control](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#change-control)
+- [CII Best Practices: Repo Public](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#repo_public)
 
 > The project's source repository MUST track what changes were made, who made the changes, and when the changes were made.
 
 **Met**
 
 Context:
-- [CII Best Practices: Change Control](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#change-control)
+- [CII Best Practices: Change Control](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#change-control)
 
 > To enable collaborative review, the project's source repository MUST include interim versions for review between releases; it MUST NOT include only final releases.
 
 **Met**
 
 Context:
-- [CII Best Practices: Change Control](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#change-control)
-- [CII Best Practices: Repo Interim](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#repo_interim)
+- [CII Best Practices: Change Control](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#change-control)
+- [CII Best Practices: Repo Interim](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#repo_interim)
 
 > It is SUGGESTED that common distributed version control software be used (e.g., git) for the project's source repository.
 
 **Met**
 
 Context:
-- [CII Best Practices: Change Control](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#change-control)
-- [CII Best Practices: Repo Distributed](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#repo_distributed)
+- [CII Best Practices: Change Control](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#change-control)
+- [CII Best Practices: Repo Distributed](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#repo_distributed)
 
 
 ## Unique version numbering
@@ -195,8 +195,8 @@ Context:
 **Met. Strictly semver**
 
 Context:
-- [CII Best Practices: Change Control](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#change-control)
-- [CII Best Practices: Version Unique](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#version_unique)
+- [CII Best Practices: Change Control](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#change-control)
+- [CII Best Practices: Version Unique](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#version_unique)
 
 
 > It is SUGGESTED that the [Semantic Versioning (SemVer)](https://semver.org/) or [Calendar Versioning (CalVer)](https://calver.org/) version numbering format be used for releases. It is SUGGESTED that those who use CalVer include a micro level value
@@ -204,15 +204,15 @@ Context:
 **Met**
 
 Context:
-- [CII Best Practices: Change Control](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#change-control)
-- [CII Best Practices: Version Semver](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#version_semver)
+- [CII Best Practices: Change Control](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#change-control)
+- [CII Best Practices: Version Semver](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#version_semver)
 
 > It is SUGGESTED that projects identify each release within their version control system. For example, it is SUGGESTED that those using git identify each release using git tags.
 
 **Met. Git tags**
 
 Context:
-- [CII Best Practices: Change Control](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#change-control)
+- [CII Best Practices: Change Control](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#change-control)
 
 
 ## Release notes
@@ -222,16 +222,16 @@ Context:
 **Met. https://github.com/nodejs/node/blob/master/CHANGELOG.md**
 
 Context:
-- [CII Best Practices: Change Control](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#change-control)
-- [CII Best Practices: Release Notes](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#release_notes)
+- [CII Best Practices: Change Control](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#change-control)
+- [CII Best Practices: Release Notes](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#release_notes)
 
 > The release notes MUST identify every publicly known run-time vulnerability fixed in this release that already had a CVE assignment or similar when the release was created. This criterion may be marked as not applicable (N/A) if users typically cannot practically update the software themselves (e.g., as is often true for kernel updates). This criterion applies only to the project results, not to its dependencies. If there are no release notes or there have been no publicly known vulnerabilities, choose N/A.
 
 **Met**
 
 Context:
-- [CII Best Practices: Change Control](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#change-control)
-- [CII Best Practices: Release Notes Vulnerabilities](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#release_notes_vulns)
+- [CII Best Practices: Change Control](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#change-control)
+- [CII Best Practices: Release Notes Vulnerabilities](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#release_notes_vulns)
 
 # Reporting
 
@@ -242,39 +242,39 @@ Context:
 **Met. https://github.com/nodejs/node/issues**
 
 Context:
-- [CII Best Practices: Reporting](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#reporting)
-- [CII Best Practices: Report Process](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#report_process)
+- [CII Best Practices: Reporting](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#reporting)
+- [CII Best Practices: Report Process](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#report_process)
 
 > The project SHOULD use an issue tracker for tracking individual issues.
 
 **Met. https://github.com/nodejs/node/issues**
 
 Context:
-- [CII Best Practices: Reporting](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#reporting)
-- [CII Best Practices: Report Process](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#report_process)
+- [CII Best Practices: Reporting](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#reporting)
+- [CII Best Practices: Report Process](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#report_process)
 
 > The project MUST acknowledge a majority of bug reports submitted in the last 2-12 months (inclusive); the response need not include a fix.
 
 **Met**
 
 Context:
-- [CII Best Practices: Reporting](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#reporting)
-- [CII Best Practices: Report Process](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#report_process)
+- [CII Best Practices: Reporting](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#reporting)
+- [CII Best Practices: Report Process](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#report_process)
 
 > The project SHOULD respond to a majority (>50%) of enhancement requests in the last 2-12 months (inclusive). 
 
 **Met**
 
 Context:
-- [CII Best Practices: Reporting](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#reporting)
-- [CII Best Practices: Report Process](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#report_process)
+- [CII Best Practices: Reporting](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#reporting)
+- [CII Best Practices: Report Process](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#report_process)
 
 > The project MUST have a publicly available archive for reports and responses for later searching. (URL required)
 
 **Met. https://github.com/nodejs/node/issues**
 
 Context:
-- [CII Best Practices: Reporting](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#reporting)
+- [CII Best Practices: Reporting](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#reporting)
 
 
 ## Vulnerability report process
@@ -284,24 +284,24 @@ Context:
 **Met. https://nodejs.org/en/security/**
 
 Context:
-- [CII Best Practices: Reporting](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#reporting)
-- [CII Best Practices: Vulnerability Report Process](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#vulnerability_report_process)
+- [CII Best Practices: Reporting](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#reporting)
+- [CII Best Practices: Vulnerability Report Process](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#vulnerability_report_process)
 
 > If private vulnerability reports are supported, the project MUST include how to send the information in a way that is kept private. (URL required)
 
 **Met. https://nodejs.org/en/security/#disclosure-policy**
 
 Context:
-- [CII Best Practices: Reporting](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#reporting)
-- [CII Best Practices: Vulnerability Report Private](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#vulnerability_report_private)
+- [CII Best Practices: Reporting](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#reporting)
+- [CII Best Practices: Vulnerability Report Private](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#vulnerability_report_private)
 
 > The project's initial response time for any vulnerability report received in the last 6 months MUST be less than or equal to 14 days.
 
 **Met. Your email will be acknowledged within 24 hours**
 
 Context:
-- [CII Best Practices: Reporting](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#reporting)
-- [CII Best Practices: Vulnerability Report Response](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#vulnerability_report_response)
+- [CII Best Practices: Reporting](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#reporting)
+- [CII Best Practices: Vulnerability Report Response](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#vulnerability_report_response)
 
 
 # Quality
@@ -313,8 +313,8 @@ Context:
 **Met. https://github.com/nodejs/node#build**
 
 Context:
-- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#quality)
-- [CII Best Practices: Build](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#build)
+- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#quality)
+- [CII Best Practices: Build](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#build)
 
 
 > It is SUGGESTED that common tools be used for building the software.
@@ -322,8 +322,8 @@ Context:
 **Met. python, make or batch file, gcc or clang**
 
 Context:
-- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#quality)
-- [CII Best Practices: Build Common Tools](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#build_common_tools)
+- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#quality)
+- [CII Best Practices: Build Common Tools](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#build_common_tools)
 
 
 > The project SHOULD be buildable using only FLOSS tools.
@@ -331,7 +331,7 @@ Context:
 **Met. python, make or batch file, gcc or clang**
 
 Context:
-- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#quality)
+- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#quality)
 
 
 ## Automated test suite
@@ -341,9 +341,9 @@ Context:
 **Met**
 
 Context:
-- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#quality)
-- [CII Best Practices: Build FLOSS Tools](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#build_floss_tools)
-- [CII Best Practices: Test](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#test)
+- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#quality)
+- [CII Best Practices: Build FLOSS Tools](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#build_floss_tools)
+- [CII Best Practices: Test](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#test)
 
 
 > A test suite SHOULD be invocable in a standard way for that language.
@@ -351,7 +351,7 @@ Context:
 **Met. make or batch file, executed using python**
 
 Context:
-- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#quality)
+- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#quality)
 
 
 > It is SUGGESTED that the test suite cover most (or ideally all) the code branches, input fields, and functionality.
@@ -359,43 +359,43 @@ Context:
 **Met**
 
 Context:
-- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#quality)
-- [CII Best Practices: Test Most](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#test_most)
-- [CII Best Practices: Test Continuos Integration](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#test_continuous_integration)
+- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#quality)
+- [CII Best Practices: Test Most](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#test_most)
+- [CII Best Practices: Test Continuos Integration](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#test_continuous_integration)
 
 > It is SUGGESTED that the project implement continuous integration (where new or changed code is frequently integrated into a central code repository and automated tests are run on the result).
 
 **Met. https://ci.nodejs.org/**
 
 Context:
-- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#quality)
-- [CII Best Practices: Test Most](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#test_most)
-- [CII Best Practices: Test Continuos Integration](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#test_continuous_integration)
+- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#quality)
+- [CII Best Practices: Test Most](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#test_most)
+- [CII Best Practices: Test Continuos Integration](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#test_continuous_integration)
 
 ## New functionality testing
 
 > The project MUST have a general policy (formal or not) that as major new functionality is added to the software produced by the project, tests of that functionality should be added to an automated test suite.
 
-**Met. https://github.com/nodejs/node/blob/main/doc/contributing/pull-requests.md#step-6-test**
+**Met. https://github.com/nodejs/node/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/doc/contributing/pull-requests.md#step-6-test**
 
 Context:
-- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#quality)
-- [CII Best Practices: Tests Policy](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#test_policy)
+- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#quality)
+- [CII Best Practices: Tests Policy](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#test_policy)
 
 > The project MUST have evidence that the test_policy for adding tests has been adhered to in the most recent major changes to the software produced by the project.
 
 **Met**
 
 Context:
-- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#quality)
+- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#quality)
 
 > It is SUGGESTED that this policy on adding tests (see test_policy) be documented in the instructions for change proposals
 
 **Met**
 
 Context:
-- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#quality)
-- [CII Best Practices: Tests Documented Added](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#tests_documented_added)
+- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#quality)
+- [CII Best Practices: Tests Documented Added](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#tests_documented_added)
 
 ## Warning flags
 
@@ -404,8 +404,8 @@ Context:
 **Met. Wall for compiling, c++ and JS linting as part of test suite**
 
 Context:
-- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#quality)
-- [CII Best Practices: Warnings](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#warnings)
+- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#quality)
+- [CII Best Practices: Warnings](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#warnings)
 
 
 > The project MUST address warnings.
@@ -413,15 +413,15 @@ Context:
 **Met**
 
 Context:
-- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#quality)
-- [CII Best Practices: Warnings Fixed](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#warnings_fixed)
+- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#quality)
+- [CII Best Practices: Warnings Fixed](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#warnings_fixed)
 
 > It is SUGGESTED that projects be maximally strict with warnings in the software produced by the project, where practical.
 
 **Met**
 
 Context:
-- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#quality)
+- [CII Best Practices: Quality](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#quality)
 
 # Security
 
@@ -432,8 +432,8 @@ Context:
 **Met**
 
 Context:
-- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#security)
-- [CII Best Practices: Know Secure Design](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#know_secure_design)
+- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#security)
+- [CII Best Practices: Know Secure Design](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#know_secure_design)
 - [Team discussion](https://github.com/nodejs/security-wg/pull/954#discussion_r1179649274)
 - [Follow up issue](https://github.com/nodejs/security-wg/issues/987)
 
@@ -442,8 +442,8 @@ Context:
 **Met**
 
 Context:
-- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#security)
-- [CII Best Practices: Know Common Errors](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#know_common_errors)
+- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#security)
+- [CII Best Practices: Know Common Errors](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#know_common_errors)
 
 ## Use basic good cryptographic practices
 
@@ -453,16 +453,16 @@ Context:
 **Met. All crypto uses openssl**
 
 Context:
-- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#security)
-- [CII Best Practices: Crypto Published](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#crypto_published)
+- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#security)
+- [CII Best Practices: Crypto Published](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#crypto_published)
 
 > If the software produced by the project is an application or library, and its primary purpose is not to implement cryptography, then it SHOULD only call on software specifically designed to implement cryptographic functions; it SHOULD NOT re-implement its own.
 
 **Met. All crypto uses openssl**
 
 Context:
-- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#security)
-- [CII Best Practices: Crypto All](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#crypto_call)
+- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#security)
+- [CII Best Practices: Crypto All](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#crypto_call)
 - [Team discussion](https://github.com/nodejs/security-wg/pull/954#discussion_r1179649710)
 
 > All functionality in the software produced by the project that depends on cryptography MUST be implementable using FLOSS.
@@ -470,16 +470,16 @@ Context:
 **Met**
 
 Context:
-- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#security)
-- [CII Best Practices: Crypto FLOSS](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#crypto_floss)
+- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#security)
+- [CII Best Practices: Crypto FLOSS](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#crypto_floss)
 
 > The security mechanisms within the software produced by the project MUST use default keylengths that at least meet the NIST minimum requirements through the year 2030 (as stated in 2012). It MUST be possible to configure the software so that smaller keylengths are completely disabled.
 
 **Met. If someone wants to, they can use custom OpenSSL configurations, custom OpenSSL providers, or even custom dynamically linked OpenSSL builds to "configure" Node.js's crypto module**
 
 Context:
-- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#security)
-- [CII Best Practices: Crypto Keylengths](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#crypto_keylength)
+- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#security)
+- [CII Best Practices: Crypto Keylengths](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#crypto_keylength)
 - [Team discussion](https://github.com/nodejs/security-wg/pull/954#discussion_r1179650439) and [also](https://github.com/nodejs/security-wg/pull/954#discussion_r1223129515)
 - [Follow up issue](https://github.com/nodejs/security-wg/issues/988)
 
@@ -488,40 +488,40 @@ Context:
 **Met**
 
 Context:
-- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#security)
-- [CII Best Practices: Crypto Working](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#crypto_working)
+- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#security)
+- [CII Best Practices: Crypto Working](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#crypto_working)
 
 > The default security mechanisms within the software produced by the project SHOULD NOT depend on cryptographic algorithms or modes with known serious weaknesses (e.g., the SHA-1 cryptographic hash algorithm or the CBC mode in SSH).
 
 **Met**
 
 Context:
-- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#security)
-- [CII Best Practices: Crypto Weaknesses](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#crypto_weaknesses)
+- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#security)
+- [CII Best Practices: Crypto Weaknesses](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#crypto_weaknesses)
 
 > The security mechanisms within the software produced by the project SHOULD implement perfect forward secrecy for key agreement protocols so a session key derived from a set of long-term keys cannot be compromised if one of the long-term keys is compromised in the future.
 
 **Met**
 
 Context:
-- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#security)
-- [CII Best Practices: Crypto PFS](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#crypto_pfs)
+- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#security)
+- [CII Best Practices: Crypto PFS](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#crypto_pfs)
 
 > If the software produced by the project causes the storing of passwords for authentication of external users, the passwords MUST be stored as iterated hashes with a per-user salt by using a key stretching (iterated) algorithm (e.g., Argon2id, Bcrypt, Scrypt, or PBKDF2). See also OWASP Password Storage Cheat Sheet.
 
 **N/A**
 
 Context:
-- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#security)
-- [CII Best Practices: Crypto Password Storage](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#crypto_password_storage)
+- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#security)
+- [CII Best Practices: Crypto Password Storage](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#crypto_password_storage)
 
 > The security mechanisms within the software produced by the project MUST generate all cryptographic keys and nonces using a cryptographically secure random number generator, and MUST NOT do so using generators that are cryptographically insecure.
 
 **Met**
 
 Context:
-- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#security)
-- [CII Best Practices: Crypto Random](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#crypto_random)
+- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#security)
+- [CII Best Practices: Crypto Random](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#crypto_random)
 
 ## Secured delivery against man-in-the-middle (MITM) attacks
 
@@ -530,14 +530,14 @@ Context:
 **Met**
 
 Context:
-- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#security)
+- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#security)
 
 > A cryptographic hash (e.g., a sha1sum) MUST NOT be retrieved over http and used without checking for a cryptographic signature.
 
 **Met. https://github.com/nodejs/node#verifying-binaries**
 
 Context:
-- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#security)
+- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#security)
 
 
 ## Publicly known vulnerabilities fixed
@@ -547,8 +547,8 @@ Context:
 **Met. For Node.js dependencies we have a repository https://github.com/nodejs/nodejs-dependency-vuln-assessments/issues containing all the public CVEs that weren't addressed in the Node.js scope and all of them are assessed regularly.**
 
 Context:
-- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#security)
-- [CII Best Practices: Vulnerabilities Fixed in 60 days](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#vulnerabilities_fixed_60_days)
+- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#security)
+- [CII Best Practices: Vulnerabilities Fixed in 60 days](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#vulnerabilities_fixed_60_days)
 - [Team discussion](https://github.com/nodejs/security-wg/pull/954#discussion_r1179651456) and [also](https://github.com/nodejs/security-wg/pull/954#discussion_r1223147346)
 - [Follow up issue](https://github.com/nodejs/security-wg/issues/986)
 
@@ -558,7 +558,7 @@ Context:
 **Met**
 
 Context:
-- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#security)
+- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#security)
 
 
 ## Other security issues
@@ -568,8 +568,8 @@ Context:
 **Met**
 
 Context:
-- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#security)
-- [CII Best Practices: Vulnerabilities Critical Fixed](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#vulnerabilities_critical_fixed)
+- [CII Best Practices: Security](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#security)
+- [CII Best Practices: Vulnerabilities Critical Fixed](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#vulnerabilities_critical_fixed)
 
 # Analysis
 
@@ -580,30 +580,30 @@ Context:
 **Met. https://scan.coverity.com/projects/node-js**
 
 Context:
-- [CII Best Practices: Analysis](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#analysis)
-- [CII Best Practices: Static Analysis](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#static_analysis)
+- [CII Best Practices: Analysis](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#analysis)
+- [CII Best Practices: Static Analysis](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#static_analysis)
 
 > It is SUGGESTED that at least one of the static analysis tools used for the static_analysis criterion include rules or approaches to look for common vulnerabilities in the analyzed language or environment.
 
 **Met**
 
 Context:
-- [CII Best Practices: Analysis](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#analysis)
+- [CII Best Practices: Analysis](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#analysis)
 
 > All medium and higher severity exploitable vulnerabilities discovered with static code analysis MUST be fixed in a timely way after they are confirmed.
 
 **Met**
 
 Context:
-- [CII Best Practices: Analysis](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#analysis)
-- [CII Best Practices: Static Analysis Fixed](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#static_analysis_fixed)
+- [CII Best Practices: Analysis](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#analysis)
+- [CII Best Practices: Static Analysis Fixed](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#static_analysis_fixed)
 
 > It is SUGGESTED that static source code analysis occur on every commit or at least daily.
 
 **Met**
 
 Context:
-- [CII Best Practices: Analysis](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#analysis)
+- [CII Best Practices: Analysis](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#analysis)
 - [Team discussion](https://github.com/nodejs/security-wg/pull/954#discussion_r1167970826)
 - [Follow up issue](https://github.com/nodejs/security-wg/issues/985)
 
@@ -614,8 +614,8 @@ Context:
 **Met. Infrastructure for running several different dynamic analysis tools is provided by the project. See: https://github.com/nodejs/node/tree/master/tools**
 
 Context:
-- [CII Best Practices: Analysis](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#analysis)
-- [CII Best Practices: Dynamic Analysis](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#dynamic_analysis)
+- [CII Best Practices: Analysis](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#analysis)
+- [CII Best Practices: Dynamic Analysis](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#dynamic_analysis)
 - [Team discussion](https://github.com/nodejs/security-wg/pull/954#discussion_r1197621044)
 
 
@@ -624,8 +624,8 @@ Context:
 **Met. valgrind for c++**
 
 Context:
-- [CII Best Practices: Analysis](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#analysis)
-- [CII Best Practices: Dynamic Analysis Unsafe](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#dynamic_analysis_unsafe)
+- [CII Best Practices: Analysis](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#analysis)
+- [CII Best Practices: Dynamic Analysis Unsafe](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#dynamic_analysis_unsafe)
 - [Team discussion](https://github.com/nodejs/security-wg/pull/954#discussion_r1179745283)
 
 
@@ -634,11 +634,11 @@ Context:
 **Met**
 
 Context:
-- [CII Best Practices: Analysis](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#analysis)
+- [CII Best Practices: Analysis](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#analysis)
 
 > All medium and higher severity exploitable vulnerabilities discovered with dynamic code analysis MUST be fixed in a timely way after they are confirmed.
 
 **Met**
 
 Context:
-- [CII Best Practices: Analysis](https://github.com/coreinfrastructure/best-practices-badge/blob/main/docs/criteria.md#analysis)
+- [CII Best Practices: Analysis](https://github.com/coreinfrastructure/best-practices-badge/blob/a51ed45fdcd8e2959781a86929f561521ac2e0e0/docs/criteria.md#analysis)


### PR DESCRIPTION
As discussed in #1175 this PR add commit references and not branch references in the links.