### PR TITLE
meta: add more info to stale message

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue is stale because it has been open many days with no activity. It will be closed soon unless the stale label is removed or a comment is made.'
+        stale-issue-message: 'This issue has been inactive for 90 days. It will be closed in 14 days unless there is further activity or the stale label is taken off.'
         stale-issue-label: 'stale'
         exempt-issue-label: 'never stale'
         days-before-stale: 90


### PR DESCRIPTION
This PR modifies the stale issue comment to contain more information (regarding the 90 days to stale, and 14 to close)