### PR TITLE
Revert "feat: add pkgjs to the ossf scorecard monitor"

### DIFF
--- a/.github/workflows/ossf-scorecard-reporting.yml
+++ b/.github/workflows/ossf-scorecard-reporting.yml
@@ -35,7 +35,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           max-request-in-parallel: 10
           discovery-enabled: true
-          discovery-orgs: 'nodejs, pkgjs'
+          discovery-orgs: 'nodejs'
       - name: Create Pull Request
         uses: gr2m/create-or-update-pull-request-action@77596e3166f328b24613f7082ab30bf2d93079d5
         env:


### PR DESCRIPTION
Reverts nodejs/security-wg#1457

My understanding is that `@pkgjs` will be handled directly in the other org