### PR TITLE
ci: fix stale workflow ('never stale' to 'never-stale')

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,6 +23,6 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been inactive for 90 days. It will be closed in 14 days unless there is further activity or the stale label is taken off.'
         stale-issue-label: 'stale'
-        exempt-issue-label: 'never stale'
+        exempt-issue-label: 'never-stale'
         days-before-stale: 90
         days-before-close: 14


### PR DESCRIPTION
Since I started following this repository, I've noticed there's an issue with the 'never stale' label. Maybe I can fix it.