### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/tools/vuln_valid/vulnValidate.js
+++ b/tools/vuln_valid/vulnValidate.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const Joi = require('joi')
-const path = require('path');
-const fs = require('fs');
+const path = require('node:path');
+const fs = require('node:fs');
 
 const coreModel = Joi.object({
   cve: Joi

--- a/vuln/index.js
+++ b/vuln/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const path = require('path');
+const path = require('node:path');
 
 module.exports = {
   paths: {


### PR DESCRIPTION
Allows redundant `require.cache` calls to be bypassed for builtin modules, saving a few yoctoseconds.

See https://nodejs.org/api/modules.html#core-modules and [discussion in nodejs/node repo regarding why `require.cache` calls are redundant for builtins](https://github.com/nodejs/node/pull/37246/files#r588397158).