### PR TITLE
ci: remove git credentials after checkout

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,6 +49,8 @@ jobs:
 
     - name: Checkout repository
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,5 +21,7 @@ jobs:
 
       - name: 'Checkout Repository'
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        with:
+          persist-credentials: false
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@5bbc3ba658137598168acb2ab73b21c432dd411b # v4.2.5

--- a/.github/workflows/ossf-scorecard-reporting.yml
+++ b/.github/workflows/ossf-scorecard-reporting.yml
@@ -21,6 +21,8 @@ jobs:
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v3.3.0
+        with:
+          persist-credentials: false
       - name: OpenSSF Scorecard Monitor
         uses: ossf/scorecard-monitor@a3a9c4cfa0684480ec5f86fa178fc22c4394b69e # v2.0.0-beta8
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        with:
+          persist-credentials: false
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2

--- a/.github/workflows/update-core-index.yml
+++ b/.github/workflows/update-core-index.yml
@@ -22,6 +22,8 @@ jobs:
         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
     - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      with:
+        persist-credentials: false
 
     - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:

--- a/.github/workflows/update-npm-index.yml
+++ b/.github/workflows/update-npm-index.yml
@@ -22,6 +22,8 @@ jobs:
         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
     - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      with:
+        persist-credentials: false
 
     - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:

--- a/.github/workflows/validate-vulnerability.yml
+++ b/.github/workflows/validate-vulnerability.yml
@@ -18,6 +18,8 @@ jobs:
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        with:
+          persist-credentials: false
 
       - name: Use Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2


### PR DESCRIPTION
This PR removes Git credentials after checkout as a security precaution by setting `persist-credentials` to false. They are not used after the initial checkout, and this stops them from accidentally leaking through a script; [see related GitHub security post](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) and [related actions/checkout issue](https://github.com/actions/checkout/issues/485).