### PR TITLE
Update all known unknowns

### DIFF
--- a/vuln/core/1.json
+++ b/vuln/core/1.json
@@ -10,5 +10,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/10.json
+++ b/vuln/core/10.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "medium"
 }

--- a/vuln/core/118.json
+++ b/vuln/core/118.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "critical"
 }

--- a/vuln/core/118.json
+++ b/vuln/core/118.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "critical"
+  "severity": "high"
 }

--- a/vuln/core/119.json
+++ b/vuln/core/119.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/12.json
+++ b/vuln/core/12.json
@@ -10,5 +10,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/120.json
+++ b/vuln/core/120.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/121.json
+++ b/vuln/core/121.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/122.json
+++ b/vuln/core/122.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/123.json
+++ b/vuln/core/123.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "medium"
 }

--- a/vuln/core/124.json
+++ b/vuln/core/124.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "medium"
 }

--- a/vuln/core/13.json
+++ b/vuln/core/13.json
@@ -10,5 +10,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/138.json
+++ b/vuln/core/138.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "medium"
 }

--- a/vuln/core/14.json
+++ b/vuln/core/14.json
@@ -10,5 +10,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "critical"
 }

--- a/vuln/core/14.json
+++ b/vuln/core/14.json
@@ -10,5 +10,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "critical"
+  "severity": "high"
 }

--- a/vuln/core/15.json
+++ b/vuln/core/15.json
@@ -10,5 +10,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "medium"
 }

--- a/vuln/core/16.json
+++ b/vuln/core/16.json
@@ -10,5 +10,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "medium"
 }

--- a/vuln/core/18.json
+++ b/vuln/core/18.json
@@ -13,5 +13,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "medium"
 }

--- a/vuln/core/19.json
+++ b/vuln/core/19.json
@@ -11,5 +11,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "medium"
 }

--- a/vuln/core/22.json
+++ b/vuln/core/22.json
@@ -10,5 +10,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "medium"
 }

--- a/vuln/core/23.json
+++ b/vuln/core/23.json
@@ -10,5 +10,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/24.json
+++ b/vuln/core/24.json
@@ -10,5 +10,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/27.json
+++ b/vuln/core/27.json
@@ -8,5 +8,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/28.json
+++ b/vuln/core/28.json
@@ -8,5 +8,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/3.json
+++ b/vuln/core/3.json
@@ -10,5 +10,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/31.json
+++ b/vuln/core/31.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/32.json
+++ b/vuln/core/32.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "medium"
 }

--- a/vuln/core/34.json
+++ b/vuln/core/34.json
@@ -8,5 +8,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/35.json
+++ b/vuln/core/35.json
@@ -8,5 +8,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "critical"
 }

--- a/vuln/core/35.json
+++ b/vuln/core/35.json
@@ -8,5 +8,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "critical"
+  "severity": "high"
 }

--- a/vuln/core/36.json
+++ b/vuln/core/36.json
@@ -10,5 +10,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/37.json
+++ b/vuln/core/37.json
@@ -10,5 +10,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/4.json
+++ b/vuln/core/4.json
@@ -10,5 +10,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "medium"
 }

--- a/vuln/core/40.json
+++ b/vuln/core/40.json
@@ -11,5 +11,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/42.json
+++ b/vuln/core/42.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/43.json
+++ b/vuln/core/43.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/44.json
+++ b/vuln/core/44.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "critical"
 }

--- a/vuln/core/45.json
+++ b/vuln/core/45.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "low"
 }

--- a/vuln/core/46.json
+++ b/vuln/core/46.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/47.json
+++ b/vuln/core/47.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "medium"
 }

--- a/vuln/core/48.json
+++ b/vuln/core/48.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/49.json
+++ b/vuln/core/49.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/5.json
+++ b/vuln/core/5.json
@@ -10,5 +10,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "medium"
 }

--- a/vuln/core/50.json
+++ b/vuln/core/50.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/51.json
+++ b/vuln/core/51.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/52.json
+++ b/vuln/core/52.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/53.json
+++ b/vuln/core/53.json
@@ -12,5 +12,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/54.json
+++ b/vuln/core/54.json
@@ -12,5 +12,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/55.json
+++ b/vuln/core/55.json
@@ -13,5 +13,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/56.json
+++ b/vuln/core/56.json
@@ -13,5 +13,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/57.json
+++ b/vuln/core/57.json
@@ -13,5 +13,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/58.json
+++ b/vuln/core/58.json
@@ -13,5 +13,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/59.json
+++ b/vuln/core/59.json
@@ -13,5 +13,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "medium"
 }

--- a/vuln/core/60.json
+++ b/vuln/core/60.json
@@ -13,5 +13,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/61.json
+++ b/vuln/core/61.json
@@ -13,5 +13,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/62.json
+++ b/vuln/core/62.json
@@ -20,5 +20,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/63.json
+++ b/vuln/core/63.json
@@ -10,5 +10,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/64.json
+++ b/vuln/core/64.json
@@ -10,5 +10,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "critical"
 }

--- a/vuln/core/65.json
+++ b/vuln/core/65.json
@@ -10,5 +10,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "critical"
 }

--- a/vuln/core/65.json
+++ b/vuln/core/65.json
@@ -10,5 +10,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "critical"
+  "severity": "high"
 }

--- a/vuln/core/69.json
+++ b/vuln/core/69.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/7.json
+++ b/vuln/core/7.json
@@ -13,5 +13,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/72.json
+++ b/vuln/core/72.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "medium"
 }

--- a/vuln/core/74.json
+++ b/vuln/core/74.json
@@ -5,9 +5,9 @@
   "vulnerable": " 10.x || 12.x || 14.x || 15.x",
   "patched": " ^10.24.0 || ^12.21.0 || ^14.16.0 || ^15.10.0",
   "ref": "https://nodejs.org/en/blog/vulnerability/february-2021-security-releases/",
-  "overview": "DNS rebinding in --inspect - Affected Node.js versions are vulnerable to denial of service attacks when the whitelist includes \u201clocalhost6\u201d. When \u201clocalhost6\u201d is not present in /etc/hosts, it is just an ordinary domain that is resolved via DNS, i.e., over network. If the attacker controls the victim's DNS server or can spoof its responses, the DNS rebinding protection can be bypassed by using the \u201clocalhost6\u201d domain. As long as the attacker uses the \u201clocalhost6\u201d domain, they can still apply the attack described in CVE-2018-7160.",
+  "overview": "DNS rebinding in --inspect - Affected Node.js versions are vulnerable to denial of service attacks when the whitelist includes “localhost6”. When “localhost6” is not present in /etc/hosts, it is just an ordinary domain that is resolved via DNS, i.e., over network. If the attacker controls the victim's DNS server or can spoof its responses, the DNS rebinding protection can be bypassed by using the “localhost6” domain. As long as the attacker uses the “localhost6” domain, they can still apply the attack described in CVE-2018-7160.",
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/74.json
+++ b/vuln/core/74.json
@@ -5,7 +5,7 @@
   "vulnerable": " 10.x || 12.x || 14.x || 15.x",
   "patched": " ^10.24.0 || ^12.21.0 || ^14.16.0 || ^15.10.0",
   "ref": "https://nodejs.org/en/blog/vulnerability/february-2021-security-releases/",
-  "overview": "DNS rebinding in --inspect - Affected Node.js versions are vulnerable to denial of service attacks when the whitelist includes “localhost6”. When “localhost6” is not present in /etc/hosts, it is just an ordinary domain that is resolved via DNS, i.e., over network. If the attacker controls the victim's DNS server or can spoof its responses, the DNS rebinding protection can be bypassed by using the “localhost6” domain. As long as the attacker uses the “localhost6” domain, they can still apply the attack described in CVE-2018-7160.",
+  "overview": "DNS rebinding in --inspect - Affected Node.js versions are vulnerable to denial of service attacks when the whitelist includes \u201clocalhost6\u201d. When \u201clocalhost6\u201d is not present in /etc/hosts, it is just an ordinary domain that is resolved via DNS, i.e., over network. If the attacker controls the victim's DNS server or can spoof its responses, the DNS rebinding protection can be bypassed by using the \u201clocalhost6\u201d domain. As long as the attacker uses the \u201clocalhost6\u201d domain, they can still apply the attack described in CVE-2018-7160.",
   "affectedEnvironments": [
     "all"
   ],

--- a/vuln/core/75.json
+++ b/vuln/core/75.json
@@ -9,5 +9,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }

--- a/vuln/core/8.json
+++ b/vuln/core/8.json
@@ -10,5 +10,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "critical"
 }

--- a/vuln/core/87.json
+++ b/vuln/core/87.json
@@ -13,5 +13,5 @@
   "affectedEnvironments": [
     "all"
   ],
-  "severity": "unknown"
+  "severity": "high"
 }


### PR DESCRIPTION
closes https://github.com/nodejs/security-wg/issues/1501

In all, I hope this better reflects the security environment and communication we are proposing within https://github.com/nodejs/nodejs.org/pull/7990



# CVE Severity Assignment

The following table provides severity ratings for Node.js CVEs that were marked as "unknown" and their new severity, based on information from the National Vulnerability Database (NVD). In cases when the their was conflict, NVD was used, not GitHub. 

| Checked| CVE Number | NVD Link | Severity |
|----|------------|----------|----------
| ✅ | CVE-2017-1000381 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2017-1000381) | High (7.5) |
| ✅ | CVE-2017-3731 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2017-3731) | High (7.5) |
| ✅ | CVE-2017-3732 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2017-3732) | Medium (5.9) |
| ✅ | CVE-2016-7055 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2016-7055) | Medium (5.9) |
| ✅ | CVE-2016-9551 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2016-9551) | ⁉️ Unknown |
| ✅ | CVE-2016-9840 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2016-9840) | High (8.8) |
| ✅ | CVE-2016-5180 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2016-5180) | Critical (9.8) |
| ✅ | CVE-2016-5172 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2016-5172) | Medium (6.5) |
| ✅ | CVE-2016-6304 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2016-6304) | High (7.5) |
| ✅ | CVE-2016-2183 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2016-2183) | High (7.5) |
| ✅ | CVE-2016-6303 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2016-6303) | Critical (9.8) |
| ✅ | CVE-2016-2178 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2016-2178) | Medium (5.5) |
| ✅ | CVE-2016-6306 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2016-6306) | Medium (5.9) |
| ✅ | CVE-2016-5325 | [NVD Link](https://nvd.nist.gov/vuln/detail/cve-2016-5325) | Medium (6.1) |
| ✅ | CVE-2016-7099 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2016-7099) | Medium (5.9) |
| ✅ | CVE-2016-2107 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2016-2107) | Medium (5.9) |
| ✅ | CVE-2016-2105 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2016-2105) | High (7.5) |
| ✅ | CVE-2016-1669 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2016-1669) | High (8.8) |
| ✅ | CVE-2016-2086 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2016-2086) | High (7.5) |
| ✅ | CVE-2016-2216 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2016-2216) | High (7.5) |
| ✅ | CVE-2016-0797 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2016-0797) | High (7.5) |
| ✅ | CVE-2016-0702 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2016-0702) | Medium (5.1) |
| ✅ | CVE-2015-8027 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2015-8027) | High (7.5) |
| ✅ | CVE-2015-6764 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2015-6764) | Critical (9.8) |
| ✅ | CVE-2015-3193 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2015-3193) | High (7.5) |
| ✅ | CVE-2015-3194 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2015-3194) | High (7.5) |
| ✅ | CVE-2015-7384 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2015-7384) | High (7.5) |
| ✅ | CVE-2017-14849 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2017-14849) | High (7.5) |
| ✅ | CVE-2017-14919 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2017-14919) | High (7.5) |
| ✅ | CVE-2017-15896 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2017-15896) | Critical (9.1) |
| ✅ | CVE-2017-15897 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2017-15897) | Low (3.1) |
| ✅ | CVE-2018-7158 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2018-7158) | High (7.5) |
| ✅ | CVE-2018-7159 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2018-7159) | Medium (5.3) |
| ✅ | CVE-2018-7160 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2018-7160) | High (8.8) |
| ✅ | CVE-2018-7161 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2018-7161) | High (7.5) |
| ✅ | CVE-2018-7162 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2018-7162) | High (7.5) |
| ✅ | CVE-2018-7164 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2018-7164) | High (7.5) |
| ✅ | CVE-2018-7166 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2018-7166) | High (7.5) |
| ✅ | CVE-2018-7167 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2018-7167) | High (7.5) |
| ✅ | CVE-2018-12115 | [NVD Link](https://nvd.nist.gov/vuln/detail/cve-2018-12115) | High (7.5) |
| ✅ | CVE-2018-12116 | [NVD Link](https://nvd.nist.gov/vuln/detail/cve-2018-12116) | High (7.5) |
| ✅ | CVE-2018-12120 | [NVD Link](https://nvd.nist.gov/vuln/detail/cve-2018-12120) | High (8.1) |
| ✅ | CVE-2018-12121 | [NVD Link](https://nvd.nist.gov/vuln/detail/cve-2018-12121) | High (7.5) |
| ✅ | CVE-2018-12122 | [NVD Link](https://nvd.nist.gov/vuln/detail/cve-2018-12122) | High (7.5) |
| ✅ | CVE-2018-12123 | [NVD Link](https://nvd.nist.gov/vuln/detail/cve-2018-12123) | Medium (4.3) |
| ✅ | CVE-2019-5737 | [NVD Link](https://nvd.nist.gov/vuln/detail/cve-2019-5737) | High (7.5) |
| ✅ | CVE-2019-5739 | [NVD Link](https://nvd.nist.gov/vuln/detail/cve-2019-5739) | High (7.5) |
| ✅ | CVE-2019-9511 | [NVD Link](https://nvd.nist.gov/vuln/detail/cve-2019-9511) | High (7.5) |
| ✅ | CVE-2019-9512 | [NVD Link](https://nvd.nist.gov/vuln/detail/cve-2019-9512) | High (7.5) |
| ✅ | CVE-2019-9513 | [NVD Link](https://nvd.nist.gov/vuln/detail/cve-2019-9513) | High (7.5) |
| ✅ | CVE-2019-9514 | [NVD Link](https://nvd.nist.gov/vuln/detail/cve-2019-9514) | High (7.5) |
| ✅ | CVE-2019-9515 | [NVD Link](https://nvd.nist.gov/vuln/detail/cve-2019-9515) | High (7.5) |
| ✅ | CVE-2019-9516 | [NVD Link](https://nvd.nist.gov/vuln/detail/cve-2019-9516) | High (7.5) |
| ✅ | CVE-2019-9517 | [NVD Link](https://nvd.nist.gov/vuln/detail/cve-2019-9517) | High (7.5) |
| ✅ | CVE-2019-9518 | [NVD Link](https://nvd.nist.gov/vuln/detail/cve-2019-9518) | High (7.5) |
| ✅ | CVE-2019-15604 | [NVD Link](https://nvd.nist.gov/vuln/detail/cve-2019-15604) | High (7.5) |
| ✅ | CVE-2019-15605 | [NVD Link](https://nvd.nist.gov/vuln/detail/cve-2019-15605) | Critical (9.8) |
| ✅ | CVE-2019-15606 | [NVD Link](https://nvd.nist.gov/vuln/detail/cve-2019-15606) | Critical (9.8) |
| ✅ | CVE-2020-1971 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2020-1971) | Medium (5.9) |
| ✅ | CVE-2020-8277 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2020-8277) | High (7.5) |
| ✅ | CVE-2021-22884 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2021-22884) | High (7.5) |
| ✅ | CVE-2021-23840 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2021-23840) | High (7.5) |
| ✅ | CVE-2021-37701 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2021-37701) | High (8.6) |
| ✅ | CVE-2021-37712 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2021-37712) | High (8.6) |
| ✅ | CVE-2021-37713 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2021-37713) | High (8.6) |
| ✅ | CVE-2021-39134 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2021-39134) | High (7.8) |
| ✅ | CVE-2021-39135 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2021-39135) | High (7.8) |
| ✅ | CVE-2023-32002 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2023-32002) | Critical (9.8) |
| ✅ | CVE-2023-32004 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2023-32004) | High (8.8) |
| ✅ | CVE-2023-32558 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2023-32558) | High (7.5) |
| ✅ | CVE-2023-32006 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2023-32006) | High (7.5) |
| ✅ | CVE-2023-32559 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2023-32559) | High (7.5) |
| ✅ | CVE-2023-32005 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2023-32005) | Medium (5.3) |
| ✅ | CVE-2023-32003 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2023-32003) | Medium (5.3) |
| ✅ | CVE-2024-22025 | [NVD Link](https://nvd.nist.gov/vuln/detail/CVE-2024-22025) | Medium (6.5) |


I verified all of these by hand. 13 unknowns remain, mostly because their entries have no CVE listed.

Example

```json
{
  "cve": [],
  "vulnerable": "5.x || 4.x || 6.x",
  "patched": "^5.12.0 || ^4.5.0 || ^6.2.1",
  "ref": "https://github.com/nodejs/node/pull/7562",
  "description": "ignore negative allocation lengths",
  "affectedEnvironments": [
    "all"
  ],
  "severity": "unknown"
}
```