### PR TITLE
ci: fix stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,6 +23,6 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been inactive for 90 days. It will be closed in 14 days unless there is further activity or the stale label is taken off.'
         stale-issue-label: 'stale'
-        exempt-issue-label: 'never-stale'
+        exempt-issue-labels: 'never-stale'
         days-before-stale: 90
         days-before-close: 14


### PR DESCRIPTION
The reason why the issues were being closed was because of a typo https://github.com/actions/stale?tab=readme-ov-file#exempt-issue-labels
alse see https://github.com/nodejs/node/blob/main/.github/workflows/close-stale-feature-requests.yml