### PR TITLE
doc: add INCIDENT_RESPONSE_PLAN.md

### DIFF
--- a/INCIDENT_RESPONSE_PLAN.md
+++ b/INCIDENT_RESPONSE_PLAN.md
@@ -32,8 +32,8 @@ Security incidents affecting Node.js may include, but are not limited to:
 The Node.js incident response team includes:
 
 - [Technical Steering Committee (TSC) members](https://github.com/nodejs/tsc)
-- [Security Team members](https://github.com/nodejs/security-wg)
-- [Security Release Stewards](https://github.com/nodejs/node/blob/main/doc/contributing/security-release-process.md#security-release-stewards)
+- [Security Release](https://github.com/orgs/nodejs/teams/security-release)
+- [Security Release Stewards](https://github.com/orgs/nodejs/teams/security-stewards)
 
 ## Incident Response Procedures
 


### PR DESCRIPTION
Inspired by https://github.com/expressjs/security-wg/blob/main/docs/incident_response_plan.md/ I think Node.js should have its own response_plan based on recent events. This should guide people to a more robust and organized workflow.

---

cc: @nodejs/tsc @nodejs/security-wg @bensternthal @nodejs/security 