### PR TITLE
doc: add "emergency" meeting with npm

### DIFF
--- a/meetings/2025-09-16-NPM.md
+++ b/meetings/2025-09-16-NPM.md
@@ -1,0 +1,74 @@
+# Meeting NPM - 2025-09-16
+
+Initial discussion available in https://openjs-foundation.slack.com/archives/CTPN0DFF0/p1758020687297589
+
+# Attendees
+
+- Rafael Gonzaga (@RafaelGSS)
+- Jean Burellier (@sheplu)
+- Wes Todd (@wesleytodd)
+- Chris de Almeida (@ctcpip)
+- Claudio Wunder (@ovflowd)
+- Pelle Wessman (@voxpelli) (Mocha)
+- Pooya Parsa (@pi0)
+- Benjamin Sternthal
+- Gar (npm)
+- Jon Jensen (@jenseng)
+- Joe Sepi
+- Joshua Godi
+- Kate Powell
+- Leo Balter (npm PM)
+- Michaela Laurencin
+- Robin Ginn (@rginn) (OpenJS ED)
+- Sam Attard
+- Sebastian Beltran
+- Ulises Gascon (@UlisesGascon)
+
+## Agenda:ish
+
+* Rafael intro
+* Leo Balter contextualizes what's going on from their side
+* Rafael / Ulises / Wes contextualizes what's going on from OpenJS side
+
+## Notes
+
+* Leo:
+  * Working with npm registry as PM
+  * Capacity is limited from NPM team.
+  * Authentication is the next target from NPM team
+  * Focused on fast iterative improvements over moonshot projects
+  * Plans to use github authentication for npm accounts (can be enforced) (not yet fully synced with npm cli team)
+
+* Gar is the contact around NPM CLI
+
+## Questions and Answers
+
+* Ask to npm team:
+  * Wes: Are there discussions happening to have 2FA Actions baked into the CLI
+  * Leo: npm team resource constrained, but auth is next up on the priority list
+  * Sam: Why 2FA requirement/enforcement is a no-go?
+    * Leo: account recovery should be fixed before enabling it. Stronger authentication (using GitHub authentication), resolves the account recovery and then enforcement of 2FA can be done.
+
+  * Jean: Currently, the safe way is someone publishing from their own computer. We need a way to configure permissions for publish a package in a more granular way. What would be a good pipeline with 2FA enforcement? Which solution do we have to ensure that a GitHub Account takeover is not successful for single and multi maintainers project?
+
+  * Gar: https://github.com/npm/rfcs/pull/92
+  * Gar: Folks left the ecosystem when they first inforced 2fa on high impact packages. This is a cultural problem, not just a technical one
+* Gar: We need you all (Us on the call) to lead here. It is not you all the call who we need to help here. 
+* Leo: having more people using it (trusted-publishing) helps drive resolving issues.
+* Wes: We can't promote trusted-publishing until some gaps are closed (2FA support). Currently, it's proven to not be safer than the usual method.
+
+* Pelle: I think trusted-publishing enables npm to leverage the wider trusted-publishing support within the GitHub Actions ecosystem and as such solving some of the constraints of the npm team, is there something to that?
+
+* Rafael: where can we help as a community?
+    * Leo: Registry is closed source, so not much to help there.
+    * Leo: Can we define the work for a better auth story?
+    * Rafael: keep this line open, npm can come to us to give feedback and help build a stronger relationship
+    * Leo: I just want to make sure I don't over promise, we need to set correct expectations. I want to be able to take 
+    action on the feedback.
+    * Wes: We're here to support npm and want to make it easier to succeed. Lots of work to do that can take place at the OpenJS Security Collab Space https://github.com/openjs-foundation/security-collab-space and at JSConf North America.
+* Jean: Lets share our express proposal with the npm tea
+* Robin: Communities are looking to GitHub/npm and OpenJS for security guidance following recent incidents. Let's align on messaging that we can promote and amplify from trusted voices. 
+
+// Questions from chat
+
+* Ulises, Can we help to increase capacity? Like helping with the Open Source pieces on npm?


### PR DESCRIPTION
Opening it into Node.js scope, but happy to move it to whatever place it suits better (maybe https://github.com/openjs-foundation/security-collab-space?)

Please review, include/remove comments you made

cc: @sheplu @wesleytodd @ctcpip @ovflowd @voxpelli @pi0 @benjamingr @wraithgar  @jenseng @joesepi @leobalter @rginn @MarshallOfSound @UlisesGascon @bjohansebas  